### PR TITLE
Fixes #18: Handle long integers as long, not single-precision floats

### DIFF
--- a/Evaluant.Calculator.Tests/Fixtures.cs
+++ b/Evaluant.Calculator.Tests/Fixtures.cs
@@ -568,7 +568,7 @@ namespace NCalc.Tests
         [TestMethod]
         public void ShouldHandleLongValues()
         {
-            Assert.AreEqual(40000000000 + 1f, new Expression("40000000000+1").Evaluate());
+            Assert.AreEqual(40_000_000_000 + 1, new Expression("40000000000+1").Evaluate());
         }
 
         [TestMethod]
@@ -651,6 +651,16 @@ namespace NCalc.Tests
             e.Parameters["var1"] = 0.5;
 
             Assert.AreEqual(3.6M, e.Evaluate());
+        }
+
+        [TestMethod]
+        public void IncorrectCalculation_NCalcAsync_Issue_4()
+        {
+            Expression e = new Expression("(1604326026000-1604325747000)/60000");
+            var evalutedResult = e.Evaluate();
+
+            Assert.IsInstanceOfType(evalutedResult, typeof(double));
+            Assert.AreEqual(4.65, (double)evalutedResult, 0.001);
         }
     }
 }

--- a/Evaluant.Calculator/Domain/Value.cs
+++ b/Evaluant.Calculator/Domain/Value.cs
@@ -62,7 +62,13 @@ namespace NCalc.Domain
             Type = ValueType.Integer;
         }
 
-        public ValueExpression(float value)
+        public ValueExpression(long value)
+        {
+            Value = value;
+            Type = ValueType.Integer;
+        }
+
+        public ValueExpression(double value)
         {
             Value = value;
             Type = ValueType.Float;


### PR DESCRIPTION
This is a port of https://github.com/ncalc/ncalc-async/pull/5. This may require a new major version, since it will change how expressions with large numbers are being evaluated.