### PR TITLE
Make Evaluate method virtual

### DIFF
--- a/src/NCalc/Expression.cs
+++ b/src/NCalc/Expression.cs
@@ -206,7 +206,7 @@ namespace NCalc
         protected Dictionary<string, IEnumerator> ParameterEnumerators;
         protected Dictionary<string, object> ParametersBackup;
 
-        public object Evaluate()
+        public virtual object Evaluate()
         {
             if (HasErrors())
             {


### PR DESCRIPTION
We need to override Evaluate method because we need to do some staff before and after evaluate method.
Example:
public override object Evaluate()
        {
            errors.Clear();
            var result = base.Evaluate();
            //return null if there was Evaluation error
            return errors.IsNullOrEmpty() ? result : null;
        }

Vladimir Jaron
