### PR TITLE
Add arithmetic support for multiple operators and types

### DIFF
--- a/src/NCalc/Domain/EvaluationVisitor.cs
+++ b/src/NCalc/Domain/EvaluationVisitor.cs
@@ -166,7 +166,7 @@ namespace NCalc.Domain
                     break;
 
                 case BinaryExpressionType.Minus:
-                    Result = Numbers.Soustract(left(), right(), _cultureInfo);
+                    Result = Numbers.Subtract(left(), right(), _cultureInfo);
                     break;
 
                 case BinaryExpressionType.Modulo:
@@ -232,7 +232,7 @@ namespace NCalc.Domain
                     break;
 
                 case UnaryExpressionType.Negate:
-                    Result = Numbers.Soustract(0, Result, _cultureInfo);
+                    Result = Numbers.Subtract(0, Result, _cultureInfo);
                     break;
 
                 case UnaryExpressionType.BitwiseNot:

--- a/src/NCalc/Numbers.cs
+++ b/src/NCalc/Numbers.cs
@@ -31,22 +31,8 @@ namespace NCalc
             switch (typeCodeA)
             {
                 case TypeCode.Boolean:
-                    switch (typeCodeB)
-                    {
-                        case TypeCode.Boolean: throw new InvalidOperationException("Operator '+' can't be applied to operands of types 'bool' and 'bool'");
-                        case TypeCode.Byte: throw new InvalidOperationException("Operator '+' can't be applied to operands of types 'bool' and 'byte'");
-                        case TypeCode.SByte: throw new InvalidOperationException("Operator '+' can't be applied to operands of types 'bool' and 'byte'");
-                        case TypeCode.Int16: throw new InvalidOperationException("Operator '+' can't be applied to operands of types 'bool' and 'byte'");
-                        case TypeCode.UInt16: throw new InvalidOperationException("Operator '+' can't be applied to operands of types 'bool' and 'byte'");
-                        case TypeCode.Int32: throw new InvalidOperationException("Operator '+' can't be applied to operands of types 'bool' and 'byte'");
-                        case TypeCode.UInt32: throw new InvalidOperationException("Operator '+' can't be applied to operands of types 'bool' and 'byte'");
-                        case TypeCode.Int64: throw new InvalidOperationException("Operator '+' can't be applied to operands of types 'bool' and 'byte'");
-                        case TypeCode.UInt64: throw new InvalidOperationException("Operator '+' can't be applied to operands of types 'bool' and 'byte'");
-                        case TypeCode.Single: throw new InvalidOperationException("Operator '+' can't be applied to operands of types 'bool' and 'byte'");
-                        case TypeCode.Double: throw new InvalidOperationException("Operator '+' can't be applied to operands of types 'bool' and 'byte'");
-                        case TypeCode.Decimal: throw new InvalidOperationException("Operator '+' can't be applied to operands of types 'bool' and 'byte'");
-                    }
-                    break;
+                    throw new InvalidOperationException(
+                        $"Operator '+' can't be applied to operands of types 'bool' and {typeCodeB}");
                 case TypeCode.Byte:
                     switch (typeCodeB)
                     {
@@ -62,8 +48,8 @@ namespace NCalc
                         case TypeCode.Single: return (Byte)a + (Single)b;
                         case TypeCode.Double: return (Byte)a + (Double)b;
                         case TypeCode.Decimal: return (Byte)a + (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '+' not implemented for 'byte' and {typeCodeB}");
                     }
-                    break;
                 case TypeCode.SByte:
                     switch (typeCodeB)
                     {
@@ -79,9 +65,8 @@ namespace NCalc
                         case TypeCode.Single: return (SByte)a + (Single)b;
                         case TypeCode.Double: return (SByte)a + (Double)b;
                         case TypeCode.Decimal: return (SByte)a + (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '+' not implemented for 'sbyte' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.Int16:
                     switch (typeCodeB)
                     {
@@ -97,9 +82,8 @@ namespace NCalc
                         case TypeCode.Single: return (Int16)a + (Single)b;
                         case TypeCode.Double: return (Int16)a + (Double)b;
                         case TypeCode.Decimal: return (Int16)a + (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '+' not implemented for types 'short' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.UInt16:
                     switch (typeCodeB)
                     {
@@ -115,9 +99,8 @@ namespace NCalc
                         case TypeCode.Single: return (UInt16)a + (Single)b;
                         case TypeCode.Double: return (UInt16)a + (Double)b;
                         case TypeCode.Decimal: return (UInt16)a + (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '+' not implemented for types 'ushort' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.Int32:
                     switch (typeCodeB)
                     {
@@ -133,13 +116,12 @@ namespace NCalc
                         case TypeCode.Single: return (Int32)a + (Single)b;
                         case TypeCode.Double: return (Int32)a + (Double)b;
                         case TypeCode.Decimal: return (Int32)a + (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '+' not implemented for types 'int' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.UInt32:
                     switch (typeCodeB)
                     {
-                        case TypeCode.Boolean: throw new InvalidOperationException("Operator '+' can't be applied to operands of types 'unit' and 'bool'");
+                        case TypeCode.Boolean: throw new InvalidOperationException("Operator '+' can't be applied to operands of types 'uint' and 'bool'");
                         case TypeCode.Byte: return (UInt32)a + (Byte)b;
                         case TypeCode.SByte: return (UInt32)a + (SByte)b;
                         case TypeCode.Int16: return (UInt32)a + (Int16)b;
@@ -151,9 +133,8 @@ namespace NCalc
                         case TypeCode.Single: return (UInt32)a + (Single)b;
                         case TypeCode.Double: return (UInt32)a + (Double)b;
                         case TypeCode.Decimal: return (UInt32)a + (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '+' not implemented for types 'uint' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.Int64:
                     switch (typeCodeB)
                     {
@@ -169,9 +150,8 @@ namespace NCalc
                         case TypeCode.Single: return (Int64)a + (Single)b;
                         case TypeCode.Double: return (Int64)a + (Double)b;
                         case TypeCode.Decimal: return (Int64)a + (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '+' not implemented for types 'long' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.UInt64:
                     switch (typeCodeB)
                     {
@@ -187,9 +167,8 @@ namespace NCalc
                         case TypeCode.Single: return (UInt64)a + (Single)b;
                         case TypeCode.Double: return (UInt64)a + (Double)b;
                         case TypeCode.Decimal: return (UInt64)a + (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '+' not implemented for types 'ulong' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.Single:
                     switch (typeCodeB)
                     {
@@ -205,9 +184,8 @@ namespace NCalc
                         case TypeCode.Single: return (Single)a + (Single)b;
                         case TypeCode.Double: return (Single)a + (Double)b;
                         case TypeCode.Decimal: return Convert.ToDecimal(a) + (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '+' not implemented for types 'float' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.Double:
                     switch (typeCodeB)
                     {
@@ -223,8 +201,8 @@ namespace NCalc
                         case TypeCode.Single: return (Double)a + (Single)b;
                         case TypeCode.Double: return (Double)a + (Double)b;
                         case TypeCode.Decimal: return Convert.ToDecimal(a) + (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '+' not implemented for types 'double' and {typeCodeB}");
                     }
-                    break;
 
                 case TypeCode.Decimal:
                     switch (typeCodeB)
@@ -241,19 +219,18 @@ namespace NCalc
                         case TypeCode.Single: return (Decimal)a + Convert.ToDecimal(b);
                         case TypeCode.Double: return (Decimal)a + Convert.ToDecimal(b);
                         case TypeCode.Decimal: return (Decimal)a + (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '+' not implemented for types 'decimal' and {typeCodeB}");
                     }
-                    break;
+                default: throw new InvalidOperationException($"Operator '+' not implemented for operands of types {typeCodeA} and {typeCodeB}");
             }
-
-            return null;
         }
 
-        public static object Soustract(object a, object b)
+        public static object Subtract(object a, object b)
         {
-            return Soustract(a, b, CultureInfo.CurrentCulture);
+            return Subtract(a, b, CultureInfo.CurrentCulture);
         }
 
-        public static object Soustract(object a, object b, CultureInfo cultureInfo)
+        public static object Subtract(object a, object b, CultureInfo cultureInfo)
         {
             a = ConvertIfString(a, cultureInfo);
             b = ConvertIfString(b, cultureInfo);
@@ -263,27 +240,13 @@ namespace NCalc
 
             switch (typeCodeA)
             {
-                case TypeCode.Boolean:
-                    switch (typeCodeB)
-                    {
-                        case TypeCode.Boolean: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'bool' and 'bool'");
-                        case TypeCode.Byte: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'bool' and 'byte'");
-                        case TypeCode.SByte: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'bool' and 'byte'");
-                        case TypeCode.Int16: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'bool' and 'byte'");
-                        case TypeCode.UInt16: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'bool' and 'byte'");
-                        case TypeCode.Int32: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'bool' and 'byte'");
-                        case TypeCode.UInt32: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'bool' and 'byte'");
-                        case TypeCode.Int64: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'bool' and 'byte'");
-                        case TypeCode.UInt64: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'bool' and 'byte'");
-                        case TypeCode.Single: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'bool' and 'byte'");
-                        case TypeCode.Double: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'bool' and 'byte'");
-                        case TypeCode.Decimal: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'bool' and 'byte'");
-                    }
-                    break;
+                case TypeCode.Boolean: 
+                    throw new InvalidOperationException($"Operator '-' can't be applied to operands of types 'bool' and {typeCodeB}");
                 case TypeCode.Byte:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'byte' and 'bool'");
+                        case TypeCode.Byte: return (Byte)a - (Byte)b;
                         case TypeCode.SByte: return (Byte)a - (SByte)b;
                         case TypeCode.Int16: return (Byte)a - (Int16)b;
                         case TypeCode.UInt16: return (Byte)a - (UInt16)b;
@@ -294,12 +257,13 @@ namespace NCalc
                         case TypeCode.Single: return (Byte)a - (Single)b;
                         case TypeCode.Double: return (Byte)a - (Double)b;
                         case TypeCode.Decimal: return (Byte)a - (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '-' not implemented for operands of types 'byte' and {typeCodeB}");
                     }
-                    break;
                 case TypeCode.SByte:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'sbyte' and 'bool'");
+                        case TypeCode.Byte: return (SByte)a - (Byte)b;
                         case TypeCode.SByte: return (SByte)a - (SByte)b;
                         case TypeCode.Int16: return (SByte)a - (Int16)b;
                         case TypeCode.UInt16: return (SByte)a - (UInt16)b;
@@ -310,13 +274,13 @@ namespace NCalc
                         case TypeCode.Single: return (SByte)a - (Single)b;
                         case TypeCode.Double: return (SByte)a - (Double)b;
                         case TypeCode.Decimal: return (SByte)a - (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '-' not implemented for operands of types 'byte' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.Int16:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'short' and 'bool'");
+                        case TypeCode.Byte: return (Int16)a - (Byte)b;
                         case TypeCode.SByte: return (Int16)a - (SByte)b;
                         case TypeCode.Int16: return (Int16)a - (Int16)b;
                         case TypeCode.UInt16: return (Int16)a - (UInt16)b;
@@ -327,13 +291,13 @@ namespace NCalc
                         case TypeCode.Single: return (Int16)a - (Single)b;
                         case TypeCode.Double: return (Int16)a - (Double)b;
                         case TypeCode.Decimal: return (Int16)a - (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '-' not implemented for operands of types 'short' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.UInt16:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'ushort' and 'bool'");
+                        case TypeCode.Byte: return (UInt16)a - (Byte)b;
                         case TypeCode.SByte: return (UInt16)a - (SByte)b;
                         case TypeCode.Int16: return (UInt16)a - (Int16)b;
                         case TypeCode.UInt16: return (UInt16)a - (UInt16)b;
@@ -344,13 +308,13 @@ namespace NCalc
                         case TypeCode.Single: return (UInt16)a - (Single)b;
                         case TypeCode.Double: return (UInt16)a - (Double)b;
                         case TypeCode.Decimal: return (UInt16)a - (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '-' not implemented for operands of types 'ushort' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.Int32:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'int' and 'bool'");
+                        case TypeCode.Byte: return (Int32)a - (Byte)b;
                         case TypeCode.SByte: return (Int32)a - (SByte)b;
                         case TypeCode.Int16: return (Int32)a - (Int16)b;
                         case TypeCode.UInt16: return (Int32)a - (UInt16)b;
@@ -361,13 +325,13 @@ namespace NCalc
                         case TypeCode.Single: return (Int32)a - (Single)b;
                         case TypeCode.Double: return (Int32)a - (Double)b;
                         case TypeCode.Decimal: return (Int32)a - (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '-' not implemented for operands of types 'int' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.UInt32:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'uint' and 'bool'");
+                        case TypeCode.Byte: return (UInt32)a - (Byte)b;
                         case TypeCode.SByte: return (UInt32)a - (SByte)b;
                         case TypeCode.Int16: return (UInt32)a - (Int16)b;
                         case TypeCode.UInt16: return (UInt32)a - (UInt16)b;
@@ -378,13 +342,13 @@ namespace NCalc
                         case TypeCode.Single: return (UInt32)a - (Single)b;
                         case TypeCode.Double: return (UInt32)a - (Double)b;
                         case TypeCode.Decimal: return (UInt32)a - (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '-' not implemented for operands of types 'uint' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.Int64:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'long' and 'bool'");
+                        case TypeCode.Byte: return (Int64)a - (Byte)b;
                         case TypeCode.SByte: return (Int64)a - (SByte)b;
                         case TypeCode.Int16: return (Int64)a - (Int16)b;
                         case TypeCode.UInt16: return (Int64)a - (UInt16)b;
@@ -395,14 +359,14 @@ namespace NCalc
                         case TypeCode.Single: return (Int64)a - (Single)b;
                         case TypeCode.Double: return (Int64)a - (Double)b;
                         case TypeCode.Decimal: return (Int64)a - (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '-' not implemented for operands of types 'long' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.UInt64:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'ulong' and 'bool'");
-                        case TypeCode.SByte: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'ulong' and 'double'");
+                        case TypeCode.Byte: return (UInt64)a - (byte)b;
+                        case TypeCode.SByte: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'ulong' and 'sbyte'");
                         case TypeCode.Int16: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'ulong' and 'short'");
                         case TypeCode.UInt16: return (UInt64)a - (UInt16)b;
                         case TypeCode.Int32: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'ulong' and 'int'");
@@ -412,13 +376,14 @@ namespace NCalc
                         case TypeCode.Single: return (UInt64)a - (Single)b;
                         case TypeCode.Double: return (UInt64)a - (Double)b;
                         case TypeCode.Decimal: return (UInt64)a - (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '-' not implemented for operands of types 'ulong' and {typeCodeB}");
                     }
-                    break;
 
                 case TypeCode.Single:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'float' and 'bool'");
+                        case TypeCode.Byte: return (Single)a - (Byte)b;
                         case TypeCode.SByte: return (Single)a - (SByte)b;
                         case TypeCode.Int16: return (Single)a - (Int16)b;
                         case TypeCode.UInt16: return (Single)a - (UInt16)b;
@@ -429,13 +394,13 @@ namespace NCalc
                         case TypeCode.Single: return (Single)a - (Single)b;
                         case TypeCode.Double: return (Single)a - (Double)b;
                         case TypeCode.Decimal: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'float' and 'decimal'");
+                        default: throw new InvalidOperationException($"Operator '-' not implemented for operands of types 'float' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.Double:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'double' and 'bool'");
+                        case TypeCode.Byte: return (Double)a - (Byte)b;
                         case TypeCode.SByte: return (Double)a - (SByte)b;
                         case TypeCode.Int16: return (Double)a - (Int16)b;
                         case TypeCode.UInt16: return (Double)a - (UInt16)b;
@@ -446,13 +411,13 @@ namespace NCalc
                         case TypeCode.Single: return (Double)a - (Single)b;
                         case TypeCode.Double: return (Double)a - (Double)b;
                         case TypeCode.Decimal: return Convert.ToDecimal(a) - (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '-' not implemented for operands of types 'double' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.Decimal:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'decimal' and 'bool'");
+                        case TypeCode.Byte: return (Decimal)a - (Byte)b;
                         case TypeCode.SByte: return (Decimal)a - (SByte)b;
                         case TypeCode.Int16: return (Decimal)a - (Int16)b;
                         case TypeCode.UInt16: return (Decimal)a - (UInt16)b;
@@ -460,14 +425,13 @@ namespace NCalc
                         case TypeCode.UInt32: return (Decimal)a - (UInt32)b;
                         case TypeCode.Int64: return (Decimal)a - (Int64)b;
                         case TypeCode.UInt64: return (Decimal)a - (UInt64)b;
-                        case TypeCode.Single: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'decimal' and 'float'");
+                        case TypeCode.Single: return (Decimal)a - Convert.ToDecimal(b);
                         case TypeCode.Double: return (Decimal)a - Convert.ToDecimal(b);
                         case TypeCode.Decimal: return (Decimal)a - (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '-' not implemented for operands of types 'decimal' and {typeCodeB}");
                     }
-                    break;
+                default: throw new InvalidOperationException($"Operator '-' not implemented for operands of types {typeCodeA} and {typeCodeB}");
             }
-
-            return null;
         }
 
         public static object Multiply(object a, object b)
@@ -485,10 +449,14 @@ namespace NCalc
 
             switch (typeCodeA)
             {
+                case TypeCode.Boolean:
+                    throw new InvalidOperationException(
+                        $"Operator '*' can't be applied to operands of types 'bool' and {typeCodeB}");
                 case TypeCode.Byte:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '*' can't be applied to operands of types 'byte' and 'bool'");
+                        case TypeCode.Byte: return (Byte)a * (Byte)b;
                         case TypeCode.SByte: return (Byte)a * (SByte)b;
                         case TypeCode.Int16: return (Byte)a * (Int16)b;
                         case TypeCode.UInt16: return (Byte)a * (UInt16)b;
@@ -499,12 +467,13 @@ namespace NCalc
                         case TypeCode.Single: return (Byte)a * (Single)b;
                         case TypeCode.Double: return (Byte)a * (Double)b;
                         case TypeCode.Decimal: return (Byte)a * (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '*' not implemented for operands of types 'byte' and {typeCodeB}");
                     }
-                    break;
                 case TypeCode.SByte:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '*' can't be applied to operands of types 'sbyte' and 'bool'");
+                        case TypeCode.Byte: return (SByte)a * (Byte)b;
                         case TypeCode.SByte: return (SByte)a * (SByte)b;
                         case TypeCode.Int16: return (SByte)a * (Int16)b;
                         case TypeCode.UInt16: return (SByte)a * (UInt16)b;
@@ -515,13 +484,13 @@ namespace NCalc
                         case TypeCode.Single: return (SByte)a * (Single)b;
                         case TypeCode.Double: return (SByte)a * (Double)b;
                         case TypeCode.Decimal: return (SByte)a * (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '*' not implemented for operands of types 'sbyte' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.Int16:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '*' can't be applied to operands of types 'short' and 'bool'");
+                        case TypeCode.Byte: return (Int16)a * (Byte)b;
                         case TypeCode.SByte: return (Int16)a * (SByte)b;
                         case TypeCode.Int16: return (Int16)a * (Int16)b;
                         case TypeCode.UInt16: return (Int16)a * (UInt16)b;
@@ -532,13 +501,13 @@ namespace NCalc
                         case TypeCode.Single: return (Int16)a * (Single)b;
                         case TypeCode.Double: return (Int16)a * (Double)b;
                         case TypeCode.Decimal: return (Int16)a * (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '*' not implemented for operands of types 'short' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.UInt16:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '*' can't be applied to operands of types 'ushort' and 'bool'");
+                        case TypeCode.Byte: return (UInt16)a * (Byte)b;
                         case TypeCode.SByte: return (UInt16)a * (SByte)b;
                         case TypeCode.Int16: return (UInt16)a * (Int16)b;
                         case TypeCode.UInt16: return (UInt16)a * (UInt16)b;
@@ -549,13 +518,13 @@ namespace NCalc
                         case TypeCode.Single: return (UInt16)a * (Single)b;
                         case TypeCode.Double: return (UInt16)a * (Double)b;
                         case TypeCode.Decimal: return (UInt16)a * (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '*' not implemented for operands of types 'ushort' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.Int32:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '*' can't be applied to operands of types 'int' and 'bool'");
+                        case TypeCode.Byte: return (Int32)a * (Byte)b;
                         case TypeCode.SByte: return (Int32)a * (SByte)b;
                         case TypeCode.Int16: return (Int32)a * (Int16)b;
                         case TypeCode.UInt16: return (Int32)a * (UInt16)b;
@@ -566,13 +535,13 @@ namespace NCalc
                         case TypeCode.Single: return (Int32)a * (Single)b;
                         case TypeCode.Double: return (Int32)a * (Double)b;
                         case TypeCode.Decimal: return (Int32)a * (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '*' not implemented for operands of types 'int' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.UInt32:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '*' can't be applied to operands of types 'uint' and 'bool'");
+                        case TypeCode.Byte: return (UInt32)a * (Byte)b;
                         case TypeCode.SByte: return (UInt32)a * (SByte)b;
                         case TypeCode.Int16: return (UInt32)a * (Int16)b;
                         case TypeCode.UInt16: return (UInt32)a * (UInt16)b;
@@ -583,13 +552,13 @@ namespace NCalc
                         case TypeCode.Single: return (UInt32)a * (Single)b;
                         case TypeCode.Double: return (UInt32)a * (Double)b;
                         case TypeCode.Decimal: return (UInt32)a * (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '*' not implemented for operands of types 'int' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.Int64:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '*' can't be applied to operands of types 'long' and 'bool'");
+                        case TypeCode.Byte: return (Int64)a * (Byte)b;
                         case TypeCode.SByte: return (Int64)a * (SByte)b;
                         case TypeCode.Int16: return (Int64)a * (Int16)b;
                         case TypeCode.UInt16: return (Int64)a * (UInt16)b;
@@ -600,13 +569,13 @@ namespace NCalc
                         case TypeCode.Single: return (Int64)a * (Single)b;
                         case TypeCode.Double: return (Int64)a * (Double)b;
                         case TypeCode.Decimal: return (Int64)a * (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '*' not implemented for operands of types 'int' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.UInt64:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '*' can't be applied to operands of types 'ulong' and 'bool'");
+                        case TypeCode.Byte: return (UInt64)a * (Byte)b;
                         case TypeCode.SByte: throw new InvalidOperationException("Operator '*' can't be applied to operands of types 'ulong' and 'sbyte'");
                         case TypeCode.Int16: throw new InvalidOperationException("Operator '*' can't be applied to operands of types 'ulong' and 'short'");
                         case TypeCode.UInt16: return (UInt64)a * (UInt16)b;
@@ -617,13 +586,14 @@ namespace NCalc
                         case TypeCode.Single: return (UInt64)a * (Single)b;
                         case TypeCode.Double: return (UInt64)a * (Double)b;
                         case TypeCode.Decimal: return (UInt64)a * (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '*' not implemented for operands of types 'ulong' and {typeCodeB}");
                     }
-                    break;
 
                 case TypeCode.Single:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '*' can't be applied to operands of types 'float' and 'bool'");
+                        case TypeCode.Byte: return (Single)a * (Byte)b;
                         case TypeCode.SByte: return (Single)a * (SByte)b;
                         case TypeCode.Int16: return (Single)a * (Int16)b;
                         case TypeCode.UInt16: return (Single)a * (UInt16)b;
@@ -633,14 +603,15 @@ namespace NCalc
                         case TypeCode.UInt64: return (Single)a * (UInt64)b;
                         case TypeCode.Single: return (Single)a * (Single)b;
                         case TypeCode.Double: return (Single)a * (Double)b;
-                        case TypeCode.Decimal: throw new InvalidOperationException("Operator '*' can't be applied to operands of types 'float' and 'decimal'");
+                        case TypeCode.Decimal: return Convert.ToDecimal(a) * (Decimal) b;
+                        default: throw new InvalidOperationException($"Operator '*' not implemented for operands of types 'float' and {typeCodeB}");
                     }
-                    break;
-
+ 
                 case TypeCode.Double:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '*' can't be applied to operands of types 'double' and 'bool'");
+                        case TypeCode.Byte: return (Double)a * (Byte)b;
                         case TypeCode.SByte: return (Double)a * (SByte)b;
                         case TypeCode.Int16: return (Double)a * (Int16)b;
                         case TypeCode.UInt16: return (Double)a * (UInt16)b;
@@ -651,13 +622,13 @@ namespace NCalc
                         case TypeCode.Single: return (Double)a * (Single)b;
                         case TypeCode.Double: return (Double)a * (Double)b;
                         case TypeCode.Decimal: return Convert.ToDecimal(a) * (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '*' not implemented for operands of types 'double' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.Decimal:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '*' can't be applied to operands of types 'decimal' and 'bool'");
+                        case TypeCode.Byte: return (Decimal)a * (Byte)b;
                         case TypeCode.SByte: return (Decimal)a * (SByte)b;
                         case TypeCode.Int16: return (Decimal)a * (Int16)b;
                         case TypeCode.UInt16: return (Decimal)a * (UInt16)b;
@@ -665,14 +636,13 @@ namespace NCalc
                         case TypeCode.UInt32: return (Decimal)a * (UInt32)b;
                         case TypeCode.Int64: return (Decimal)a * (Int64)b;
                         case TypeCode.UInt64: return (Decimal)a * (UInt64)b;
-                        case TypeCode.Single: throw new InvalidOperationException("Operator '*' can't be applied to operands of types 'decimal' and 'float'");
+                        case TypeCode.Single: return (Decimal) a * Convert.ToDecimal(b);
                         case TypeCode.Double: return (Decimal)a * Convert.ToDecimal(b);
                         case TypeCode.Decimal: return (Decimal)a * (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '*' not implemented for operands of types 'decimal' and {typeCodeB}");
                     }
-                    break;
+                default: throw new InvalidOperationException($"Operator '*' not implemented for operands of types {typeCodeA} and {typeCodeB}");
             }
-
-            return null;
         }
         
         public static object Divide(object a, object b)
@@ -690,10 +660,14 @@ namespace NCalc
 
             switch (typeCodeA)
             {
+                case TypeCode.Boolean:
+                    throw new InvalidOperationException(
+                        $"Operator '/' can't be applied to operands of types 'bool' and {typeCodeB}");
                 case TypeCode.Byte:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '/' can't be applied to operands of types 'byte' and 'bool'");
+                        case TypeCode.Byte: return (Byte)a / (Byte)b;
                         case TypeCode.SByte: return (Byte)a / (SByte)b;
                         case TypeCode.Int16: return (Byte)a / (Int16)b;
                         case TypeCode.UInt16: return (Byte)a / (UInt16)b;
@@ -704,12 +678,13 @@ namespace NCalc
                         case TypeCode.Single: return (Byte)a / (Single)b;
                         case TypeCode.Double: return (Byte)a / (Double)b;
                         case TypeCode.Decimal: return (Byte)a / (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '/' not implemented for operands of types 'decimal' and {typeCodeB}");
                     }
-                    break;
                 case TypeCode.SByte:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '/' can't be applied to operands of types 'sbyte' and 'bool'");
+                        case TypeCode.Byte: return (SByte)a / (Byte)b;
                         case TypeCode.SByte: return (SByte)a / (SByte)b;
                         case TypeCode.Int16: return (SByte)a / (Int16)b;
                         case TypeCode.UInt16: return (SByte)a / (UInt16)b;
@@ -720,13 +695,14 @@ namespace NCalc
                         case TypeCode.Single: return (SByte)a / (Single)b;
                         case TypeCode.Double: return (SByte)a / (Double)b;
                         case TypeCode.Decimal: return (SByte)a / (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '/' not implemented for operands of types 'decimal' and {typeCodeB}");
                     }
-                    break;
 
                 case TypeCode.Int16:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '/' can't be applied to operands of types 'short' and 'bool'");
+                        case TypeCode.Byte: return (Int16)a / (Byte)b;
                         case TypeCode.SByte: return (Int16)a / (SByte)b;
                         case TypeCode.Int16: return (Int16)a / (Int16)b;
                         case TypeCode.UInt16: return (Int16)a / (UInt16)b;
@@ -737,13 +713,13 @@ namespace NCalc
                         case TypeCode.Single: return (Int16)a / (Single)b;
                         case TypeCode.Double: return (Int16)a / (Double)b;
                         case TypeCode.Decimal: return (Int16)a / (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '/' not implemented for operands of types 'decimal' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.UInt16:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '/' can't be applied to operands of types 'ushort' and 'bool'");
+                        case TypeCode.Byte: return (UInt16)a / (Byte)b;
                         case TypeCode.SByte: return (UInt16)a / (SByte)b;
                         case TypeCode.Int16: return (UInt16)a / (Int16)b;
                         case TypeCode.UInt16: return (UInt16)a / (UInt16)b;
@@ -754,13 +730,13 @@ namespace NCalc
                         case TypeCode.Single: return (UInt16)a / (Single)b;
                         case TypeCode.Double: return (UInt16)a / (Double)b;
                         case TypeCode.Decimal: return (UInt16)a / (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '/' not implemented for operands of types 'ushort' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.Int32:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '/' can't be applied to operands of types 'int' and 'bool'");
+                        case TypeCode.Byte: return (Int32)a / (Byte)b;
                         case TypeCode.SByte: return (Int32)a / (SByte)b;
                         case TypeCode.Int16: return (Int32)a / (Int16)b;
                         case TypeCode.UInt16: return (Int32)a / (UInt16)b;
@@ -771,13 +747,13 @@ namespace NCalc
                         case TypeCode.Single: return (Int32)a / (Single)b;
                         case TypeCode.Double: return (Int32)a / (Double)b;
                         case TypeCode.Decimal: return (Int32)a / (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '/' not implemented for operands of types 'int' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.UInt32:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '/' can't be applied to operands of types 'uint' and 'bool'");
+                        case TypeCode.Byte: return (UInt32)a / (Byte)b;
                         case TypeCode.SByte: return (UInt32)a / (SByte)b;
                         case TypeCode.Int16: return (UInt32)a / (Int16)b;
                         case TypeCode.UInt16: return (UInt32)a / (UInt16)b;
@@ -788,13 +764,13 @@ namespace NCalc
                         case TypeCode.Single: return (UInt32)a / (Single)b;
                         case TypeCode.Double: return (UInt32)a / (Double)b;
                         case TypeCode.Decimal: return (UInt32)a / (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '/' not implemented for operands of types 'uint' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.Int64:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '/' can't be applied to operands of types 'long' and 'bool'");
+                        case TypeCode.Byte: return (Int64)a / (Byte)b;
                         case TypeCode.SByte: return (Int64)a / (SByte)b;
                         case TypeCode.Int16: return (Int64)a / (Int16)b;
                         case TypeCode.UInt16: return (Int64)a / (UInt16)b;
@@ -805,13 +781,13 @@ namespace NCalc
                         case TypeCode.Single: return (Int64)a / (Single)b;
                         case TypeCode.Double: return (Int64)a / (Double)b;
                         case TypeCode.Decimal: return (Int64)a / (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '/' not implemented for operands of types 'long' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.UInt64:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '-' can't be applied to operands of types 'ulong' and 'bool'");
+                        case TypeCode.Byte: throw new InvalidOperationException("Operator '/' can't be applied to operands of types 'ulong' and 'byte'");
                         case TypeCode.SByte: throw new InvalidOperationException("Operator '/' can't be applied to operands of types 'ulong' and 'sbyte'");
                         case TypeCode.Int16: throw new InvalidOperationException("Operator '/' can't be applied to operands of types 'ulong' and 'short'");
                         case TypeCode.UInt16: return (UInt64)a / (UInt16)b;
@@ -822,13 +798,13 @@ namespace NCalc
                         case TypeCode.Single: return (UInt64)a / (Single)b;
                         case TypeCode.Double: return (UInt64)a / (Double)b;
                         case TypeCode.Decimal: return (UInt64)a / (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '/' not implemented for operands of types 'ulong' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.Single:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '/' can't be applied to operands of types 'float' and 'bool'");
+                        case TypeCode.Byte: return (Single)a / (Byte)b;
                         case TypeCode.SByte: return (Single)a / (SByte)b;
                         case TypeCode.Int16: return (Single)a / (Int16)b;
                         case TypeCode.UInt16: return (Single)a / (UInt16)b;
@@ -839,13 +815,13 @@ namespace NCalc
                         case TypeCode.Single: return (Single)a / (Single)b;
                         case TypeCode.Double: return (Single)a / (Double)b;
                         case TypeCode.Decimal: throw new InvalidOperationException("Operator '/' can't be applied to operands of types 'float' and 'decimal'");
+                        default: throw new InvalidOperationException($"Operator '/' not implemented for operands of types 'ulong' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.Double:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '/' can't be applied to operands of types 'double' and 'bool'");
+                        case TypeCode.Byte: return (Double)a / (Byte)b;
                         case TypeCode.SByte: return (Double)a / (SByte)b;
                         case TypeCode.Int16: return (Double)a / (Int16)b;
                         case TypeCode.UInt16: return (Double)a / (UInt16)b;
@@ -856,13 +832,13 @@ namespace NCalc
                         case TypeCode.Single: return (Double)a / (Single)b;
                         case TypeCode.Double: return (Double)a / (Double)b;
                         case TypeCode.Decimal: return Convert.ToDecimal(a) / (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '/' not implemented for operands of types 'double' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.Decimal:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '/' can't be applied to operands of types 'decimal' and 'bool'");
+                        case TypeCode.Byte: return (Decimal)a / (SByte)b;
                         case TypeCode.SByte: return (Decimal)a / (SByte)b;
                         case TypeCode.Int16: return (Decimal)a / (Int16)b;
                         case TypeCode.UInt16: return (Decimal)a / (UInt16)b;
@@ -873,11 +849,10 @@ namespace NCalc
                         case TypeCode.Single: return (Decimal)a / Convert.ToDecimal(b);
                         case TypeCode.Double: return (Decimal)a / Convert.ToDecimal(b);
                         case TypeCode.Decimal: return (Decimal)a / (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '/' not implemented for operands of types 'decimal' and {typeCodeB}");
                     }
-                    break;
+                default: throw new InvalidOperationException($"Operator '/' not implemented for operands of types {typeCodeA} and {typeCodeB}");
             }
-
-            return null;
         }
 
         public static object Modulo(object a, object b)
@@ -895,10 +870,14 @@ namespace NCalc
 
             switch (typeCodeA)
             {
+                case TypeCode.Boolean:
+                    throw new InvalidOperationException(
+                        $"Operator '%' can't be applied to operands of types 'bool' and {typeCodeB}");
                 case TypeCode.Byte:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '%' can't be applied to operands of types 'byte' and 'bool'");
+                        case TypeCode.Byte: return (Byte)a % (SByte)b;
                         case TypeCode.SByte: return (Byte)a % (SByte)b;
                         case TypeCode.Int16: return (Byte)a % (Int16)b;
                         case TypeCode.UInt16: return (Byte)a % (UInt16)b;
@@ -909,12 +888,13 @@ namespace NCalc
                         case TypeCode.Single: return (Byte)a % (Single)b;
                         case TypeCode.Double: return (Byte)a % (Double)b;
                         case TypeCode.Decimal: return (Byte)a % (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '/' not implemented for operands of types 'byte' and {typeCodeB}");
                     }
-                    break;
                 case TypeCode.SByte:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '%' can't be applied to operands of types 'sbyte' and 'bool'");
+                        case TypeCode.Byte: return (SByte)a % (Byte)b;
                         case TypeCode.SByte: return (SByte)a % (SByte)b;
                         case TypeCode.Int16: return (SByte)a % (Int16)b;
                         case TypeCode.UInt16: return (SByte)a % (UInt16)b;
@@ -925,13 +905,13 @@ namespace NCalc
                         case TypeCode.Single: return (SByte)a % (Single)b;
                         case TypeCode.Double: return (SByte)a % (Double)b;
                         case TypeCode.Decimal: return (SByte)a % (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '/' not implemented for operands of types 'sbyte' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.Int16:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '%' can't be applied to operands of types 'short' and 'bool'");
+                        case TypeCode.Byte: return (Int16)a % (Byte)b;
                         case TypeCode.SByte: return (Int16)a % (SByte)b;
                         case TypeCode.Int16: return (Int16)a % (Int16)b;
                         case TypeCode.UInt16: return (Int16)a % (UInt16)b;
@@ -942,13 +922,13 @@ namespace NCalc
                         case TypeCode.Single: return (Int16)a % (Single)b;
                         case TypeCode.Double: return (Int16)a % (Double)b;
                         case TypeCode.Decimal: return (Int16)a % (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '%' not implemented for operands of types 'short' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.UInt16:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '%' can't be applied to operands of types 'ushort' and 'bool'");
+                        case TypeCode.Byte: return (UInt16)a % (SByte)b;
                         case TypeCode.SByte: return (UInt16)a % (SByte)b;
                         case TypeCode.Int16: return (UInt16)a % (Int16)b;
                         case TypeCode.UInt16: return (UInt16)a % (UInt16)b;
@@ -959,13 +939,13 @@ namespace NCalc
                         case TypeCode.Single: return (UInt16)a % (Single)b;
                         case TypeCode.Double: return (UInt16)a % (Double)b;
                         case TypeCode.Decimal: return (UInt16)a % (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '%' not implemented for operands of types 'ushort' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.Int32:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '%' can't be applied to operands of types 'int' and 'bool'");
+                        case TypeCode.Byte: return (Int32)a % (Byte)b;
                         case TypeCode.SByte: return (Int32)a % (SByte)b;
                         case TypeCode.Int16: return (Int32)a % (Int16)b;
                         case TypeCode.UInt16: return (Int32)a % (UInt16)b;
@@ -976,13 +956,13 @@ namespace NCalc
                         case TypeCode.Single: return (Int32)a % (Single)b;
                         case TypeCode.Double: return (Int32)a % (Double)b;
                         case TypeCode.Decimal: return (Int32)a % (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '%' not implemented for operands of types 'int' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.UInt32:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '%' can't be applied to operands of types 'uint' and 'bool'");
+                        case TypeCode.Byte: return (UInt32)a % (Byte)b;
                         case TypeCode.SByte: return (UInt32)a % (SByte)b;
                         case TypeCode.Int16: return (UInt32)a % (Int16)b;
                         case TypeCode.UInt16: return (UInt32)a % (UInt16)b;
@@ -993,13 +973,13 @@ namespace NCalc
                         case TypeCode.Single: return (UInt32)a % (Single)b;
                         case TypeCode.Double: return (UInt32)a % (Double)b;
                         case TypeCode.Decimal: return (UInt32)a % (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '%' not implemented for operands of types 'uint' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.Int64:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '%' can't be applied to operands of types 'long' and 'bool'");
+                        case TypeCode.Byte: return (Int64)a % (Byte)b;
                         case TypeCode.SByte: return (Int64)a % (SByte)b;
                         case TypeCode.Int16: return (Int64)a % (Int16)b;
                         case TypeCode.UInt16: return (Int64)a % (UInt16)b;
@@ -1010,13 +990,13 @@ namespace NCalc
                         case TypeCode.Single: return (Int64)a % (Single)b;
                         case TypeCode.Double: return (Int64)a % (Double)b;
                         case TypeCode.Decimal: return (Int64)a % (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '%' not implemented for operands of types 'long' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.UInt64:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '%' can't be applied to operands of types 'ulong' and 'bool'");
+                        case TypeCode.Byte: throw new InvalidOperationException("Operator '%' can't be applied to operands of types 'ulong' and 'byte'");
                         case TypeCode.SByte: throw new InvalidOperationException("Operator '%' can't be applied to operands of types 'ulong' and 'sbyte'");
                         case TypeCode.Int16: throw new InvalidOperationException("Operator '%' can't be applied to operands of types 'ulong' and 'short'");
                         case TypeCode.UInt16: return (UInt64)a % (UInt16)b;
@@ -1027,13 +1007,13 @@ namespace NCalc
                         case TypeCode.Single: return (UInt64)a % (Single)b;
                         case TypeCode.Double: return (UInt64)a % (Double)b;
                         case TypeCode.Decimal: return (UInt64)a % (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '%' not implemented for operands of types 'ulong' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.Single:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '%' can't be applied to operands of types 'float' and 'bool'");
+                        case TypeCode.Byte: return (Single)a % (Byte)b;
                         case TypeCode.SByte: return (Single)a % (SByte)b;
                         case TypeCode.Int16: return (Single)a % (Int16)b;
                         case TypeCode.UInt16: return (Single)a % (UInt16)b;
@@ -1044,13 +1024,13 @@ namespace NCalc
                         case TypeCode.Single: return (Single)a % (Single)b;
                         case TypeCode.Double: return (Single)a % (Double)b;
                         case TypeCode.Decimal: throw new InvalidOperationException("Operator '%' can't be applied to operands of types 'float' and 'decimal'");
+                        default: throw new InvalidOperationException($"Operator '%' not implemented for operands of types 'long' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.Double:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '%' can't be applied to operands of types 'double' and 'bool'");
+                        case TypeCode.Byte: return (Double)a % (Byte)b;
                         case TypeCode.SByte: return (Double)a % (SByte)b;
                         case TypeCode.Int16: return (Double)a % (Int16)b;
                         case TypeCode.UInt16: return (Double)a % (UInt16)b;
@@ -1061,13 +1041,13 @@ namespace NCalc
                         case TypeCode.Single: return (Double)a % (Single)b;
                         case TypeCode.Double: return (Double)a % (Double)b;
                         case TypeCode.Decimal: throw new InvalidOperationException("Operator '%' can't be applied to operands of types 'double' and 'decimal'");
+                        default: throw new InvalidOperationException($"Operator '%' not implemented for operands of types 'double' and {typeCodeB}");
                     }
-                    break;
-
                 case TypeCode.Decimal:
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '%' can't be applied to operands of types 'decimal' and 'bool'");
+                        case TypeCode.Byte: return (Decimal)a % (Byte)b;
                         case TypeCode.SByte: return (Decimal)a % (SByte)b;
                         case TypeCode.Int16: return (Decimal)a % (Int16)b;
                         case TypeCode.UInt16: return (Decimal)a % (UInt16)b;
@@ -1078,11 +1058,10 @@ namespace NCalc
                         case TypeCode.Single: throw new InvalidOperationException("Operator '%' can't be applied to operands of types 'decimal' and 'float'");
                         case TypeCode.Double: throw new InvalidOperationException("Operator '%' can't be applied to operands of types 'decimal' and 'decimal'");
                         case TypeCode.Decimal: return (Decimal)a % (Decimal)b;
+                        default: throw new InvalidOperationException($"Operator '%' not implemented for operands of types 'decimal' and {typeCodeB}");
                     }
-                    break;
+                default: throw new InvalidOperationException($"Operator '+' not implemented for operands of types {typeCodeA} and {typeCodeB}");
             }
-
-            return null;
         }
 
         public static object Max(object a, object b)
@@ -1111,6 +1090,7 @@ namespace NCalc
             }
 
             TypeCode typeCodeA = Type.GetTypeCode(a.GetType());
+            TypeCode typeCodeB = Type.GetTypeCode(b.GetType());
 
             switch (typeCodeA)
             {
@@ -1136,9 +1116,8 @@ namespace NCalc
                     return Math.Max((Double)a, Convert.ToDouble(b));
                 case TypeCode.Decimal:
                     return Math.Max((Decimal)a, Convert.ToDecimal(b));
+                default: throw new InvalidOperationException($"Max not implemented for parameters of {typeCodeA} and {typeCodeB}");
             }
-
-            return null;
         }
 
         public static object Min(object a, object b)
@@ -1167,6 +1146,7 @@ namespace NCalc
             }
 
             TypeCode typeCodeA = Type.GetTypeCode(a.GetType());
+            TypeCode typeCodeB = Type.GetTypeCode(b.GetType());
 
             switch (typeCodeA)
             {
@@ -1192,10 +1172,9 @@ namespace NCalc
                     return Math.Min((Double)a, Convert.ToDouble(b));
                 case TypeCode.Decimal:
                     return Math.Min((Decimal)a, Convert.ToDecimal(b));
+                default: throw new InvalidOperationException($"Max not implemented for parameters of {typeCodeA} and {typeCodeB}");
+
             }
-
-            return null;
         }
-
     }
 }

--- a/src/NCalc/Numbers.cs
+++ b/src/NCalc/Numbers.cs
@@ -877,7 +877,7 @@ namespace NCalc
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '%' can't be applied to operands of types 'byte' and 'bool'");
-                        case TypeCode.Byte: return (Byte)a % (SByte)b;
+                        case TypeCode.Byte: return (Byte)a % (Byte)b;
                         case TypeCode.SByte: return (Byte)a % (SByte)b;
                         case TypeCode.Int16: return (Byte)a % (Int16)b;
                         case TypeCode.UInt16: return (Byte)a % (UInt16)b;
@@ -928,7 +928,7 @@ namespace NCalc
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '%' can't be applied to operands of types 'ushort' and 'bool'");
-                        case TypeCode.Byte: return (UInt16)a % (SByte)b;
+                        case TypeCode.Byte: return (UInt16)a % (Byte)b;
                         case TypeCode.SByte: return (UInt16)a % (SByte)b;
                         case TypeCode.Int16: return (UInt16)a % (Int16)b;
                         case TypeCode.UInt16: return (UInt16)a % (UInt16)b;
@@ -996,7 +996,7 @@ namespace NCalc
                     switch (typeCodeB)
                     {
                         case TypeCode.Boolean: throw new InvalidOperationException("Operator '%' can't be applied to operands of types 'ulong' and 'bool'");
-                        case TypeCode.Byte: throw new InvalidOperationException("Operator '%' can't be applied to operands of types 'ulong' and 'byte'");
+                        case TypeCode.Byte: return (UInt64)a % (Byte)b;
                         case TypeCode.SByte: throw new InvalidOperationException("Operator '%' can't be applied to operands of types 'ulong' and 'sbyte'");
                         case TypeCode.Int16: throw new InvalidOperationException("Operator '%' can't be applied to operands of types 'ulong' and 'short'");
                         case TypeCode.UInt16: return (UInt64)a % (UInt16)b;

--- a/test/NCalc.Tests/Fixtures.cs
+++ b/test/NCalc.Tests/Fixtures.cs
@@ -840,8 +840,8 @@ namespace NCalc.Tests
                         {
                             Parameters =
                             {
-                                ["x"] = Convert.ChangeType(lhsValue, typecodeA),
-                                ["y"] = Convert.ChangeType(rhsValue, typecodeB)
+                                ["x"] = Convert.ChangeType(1, typecodeA),
+                                ["y"] = Convert.ChangeType(1, typecodeB)
                             }
                         }
                         .Evaluate(),$"{expr}: {typecodeA}, {typecodeB}");
@@ -1012,7 +1012,7 @@ namespace NCalc.Tests
         {
             // https://github.com/ncalc/ncalc/issues/58
             var expectedResult = 0;
-            var operand = "/";
+            var operand = "%";
             var lhsValue = 50;
             var rhsValue = 50;
 
@@ -1037,9 +1037,9 @@ namespace NCalc.Tests
             shouldNotWork[TypeCode.Int64] = new List<TypeCode> { TypeCode.Boolean, TypeCode.UInt64 };
             shouldNotWork[TypeCode.UInt64] = new List<TypeCode>
                 { TypeCode.Boolean, TypeCode.SByte, TypeCode.Int16, TypeCode.Int32, TypeCode.Int64 };
-            shouldNotWork[TypeCode.Single] = new List<TypeCode> { TypeCode.Boolean };
-            shouldNotWork[TypeCode.Double] = new List<TypeCode> { TypeCode.Boolean };
-            shouldNotWork[TypeCode.Decimal] = new List<TypeCode> { TypeCode.Boolean };
+            shouldNotWork[TypeCode.Single] = new List<TypeCode> { TypeCode.Boolean, TypeCode.Decimal };
+            shouldNotWork[TypeCode.Double] = new List<TypeCode> { TypeCode.Boolean, TypeCode.Decimal };
+            shouldNotWork[TypeCode.Decimal] = new List<TypeCode> { TypeCode.Boolean, TypeCode.Single, TypeCode.Double };
 
             // These should all work and return a value
             foreach (var typecodeA in allTypes)


### PR DESCRIPTION
This PR attempts to fix a number of inconsistencies I found while using the library:

1. Most operands did not support `byte`. This has been fixed. 
2. Implemented unit tests for `Add`, `Subtract`, `Multiply`, and `Modulo`.
3. There were inconsistencies between supported types and operands. As much as possible, this has been fixed.
4. `Soustract` was changed to `Subtract` as the rest of the functions are in English. I am not sure if this is part of an exposed API; if it is I will revert it. As far as I can tell `Soustract` was/is only used by `EvaluationVisitor`.
5. Various misspellings were corrected and if the type was wrong in the error message reported upwards that was also fixed.
6. Default handling was put in switches to make it more ergonomic for users (eg a usable error). Right now if you evaluate an expression with variables that resolves to a type that is not supported in `Numbers` it is very difficult to debug as a `NullExceptionError` is thrown from deep in the library.

I am not sure I understand division enough yet to make it match the other operands. It is not like the others in that it modifies its inputs before evaluation, and it seems some of the tests rely on the fact that it only converts the left hand side of something to a `double` if it is not decimal / single / double (eg `IsReal()` usage in `EvaluationVisitor`). 

Coercing both lhs / rhs to `Double` based on what `IsReal` returns broke a number of other tests so I am leaving it as is and not implementing a test for division in this PR. That said, this means there are some unusual consequences of how variable division works currently:

```csharp
var expression = "X / Y";
Expression e = new(expression);
e.Parameters["X"] = true;
e.Parameters["Y"] = 1;
var ret = e.Evaluate(); // Evaluates to 1 (eg 1/1 = 1)
```

vs

```csharp
var expression = "X / Y";
Expression e = new(expression);
e.Parameters["X"] = 1;
e.Parameters["Y"] = true;
var ret = e.Evaluate(); // Throws InvalidOperationException - Operator '/' can't be applied to operands of types 'double' and 'bool'
```

Thanks a lot for your work on this library! I hope this is a useful PR.
