### PR TITLE
Add parameterless constructor to ValueExpression

### DIFF
--- a/src/NCalc/Domain/Value.cs
+++ b/src/NCalc/Domain/Value.cs
@@ -4,6 +4,8 @@ namespace NCalc.Domain
 {
     public class ValueExpression : LogicalExpression
     {
+        public ValueExpression() {}
+        
         public ValueExpression(object value, ValueType type)
         {
             Value = value;


### PR DESCRIPTION
Add a parameterless constructor to ValueExpression that will allow serialization of the class. Will create a separate PR for the cache changes.

With this change, you can use Newtonsoft to serialize the `LogicalExpression`.

```
var compiled = Expression.Compile(expression, true);
var json = JsonConvert.SerializeObject(compiled, new JsonSerializerSettings
{
    TypeNameHandling = TypeNameHandling.All // We need this to allow serializing abstract classes
});
```

Also, see https://github.com/ncalc/ncalc/issues/60