### PR TITLE
Add reference to NCalcJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,7 @@ Developed by David, Dan and all at [Panoramic Data](https://github.com/panoramic
 
 Javascript Interpreter for .NET by [Sébastien Ros](https://github.com/sebastienros), the author of NCalc library.  
 Runs on any modern .NET platform as it supports .NET Standard 2.0 and .NET 4.6.1 targets (and up).
+
+### [NCalcJS](https://github.com/thomashambach/ncalcjs)
+
+A Typescript/Javascript port of NCalc.


### PR DESCRIPTION
Hi! 

Not sure if you're interested in adding the reference to the port I did of this library to Typescript/Javascript. But perhaps if you are, I created this PR :)

As far as the unit tests and my own programs tell me, it is fully compatible with expressions that run on NCalc C#.

Thanks!