### PR TITLE
Abs convert to double

### DIFF
--- a/src/NCalc/Domain/EvaluationVisitor.cs
+++ b/src/NCalc/Domain/EvaluationVisitor.cs
@@ -290,7 +290,7 @@ namespace NCalc.Domain
                     if (function.Expressions.Length != 1)
                         throw new ArgumentException("Abs() takes exactly 1 argument");
 
-                    Result = Math.Abs(Convert.ToDecimal(
+                    Result = Math.Abs(Convert.ToDouble(
                         Evaluate(function.Expressions[0]), _cultureInfo)
                         );
 


### PR DESCRIPTION
Convert "Abs" function parameter to double to stay consistent with other functions (they're all using double parameters).