### PR TITLE
Fix issue with CommonTypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,35 @@ e.EvaluateParameter += delegate(string name, ParameterArgs args)
 Debug.Assert(117.07 == e.Evaluate());
 ```
 
+**Caching in a distributed cache**
+
+This example uses [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json/).
+
+Serializing
+```c#
+var compiled = Expression.Compile(expression, true);
+var serialized = JsonConvert.SerializeObject(compiled, new JsonSerializerSettings
+{
+    TypeNameHandling = TypeNameHandling.All // We need this to allow serializing abstract classes
+});
+```
+
+Deserializing
+```c#
+var deserialized = JsonConvert.DeserializeObject<LogicalExpression>(serialized, new JsonSerializerSettings
+{
+    TypeNameHandling = TypeNameHandling.All
+});
+
+Expression.CacheEnabled = false; // We cannot use NCalc's built in cache at the same time.
+var exp = new Expression(deserialized);
+exp.Parameters = new Dictionary<string, object> {
+    {"waterlevel", inputValue}
+};
+
+var evaluated = exp.Evaluate();
+```
+
 ## Related projects
 
 ### [NCalc-Async](https://github.com/ncalc/ncalc-async/)

--- a/src/NCalc/Domain/EvaluationVisitor.cs
+++ b/src/NCalc/Domain/EvaluationVisitor.cs
@@ -37,7 +37,7 @@ namespace NCalc.Domain
             throw new Exception("The method or operation is not implemented.");
         }
 
-        private static Type[] CommonTypes = new[] { typeof(Int64), typeof(Double), typeof(Boolean), typeof(String), typeof(Decimal) };
+        private static Type[] CommonTypes = new[] { typeof(Double), typeof(Int64), typeof(Boolean), typeof(String), typeof(Decimal) };
 
         /// <summary>
         /// Gets the the most precise type.

--- a/test/NCalc.Tests/Fixtures.cs
+++ b/test/NCalc.Tests/Fixtures.cs
@@ -1148,13 +1148,6 @@ namespace NCalc.Tests
             }
         }
 
-        // [Theory]
-        // [InlineData(@"(level > 1 AND level <= 3)", false, 3.2)]
-        // [InlineData(@"(level > 3 AND level <= 5)", true, 3.2)]
-        // [InlineData(@"(level > 1 AND level <= 3)", false, 3.1)]
-        // [InlineData(@"(level > 3 AND level <= 5)", true, 3.1)]
-        // [InlineData(@"(3 < level AND 5 >= level)", true, 3.1)]
-        // [InlineData(@"(3.2 < level AND 5.3 >= level)", true, 4)]
         [TestMethod]
         public void SerializeAndDeserialize_ShouldWork()
         {

--- a/test/NCalc.Tests/Fixtures.cs
+++ b/test/NCalc.Tests/Fixtures.cs
@@ -1156,8 +1156,8 @@ namespace NCalc.Tests
             ExecuteTest(@"(waterlevel > 3 AND waterlevel <= 5)", true, 3.2);
             ExecuteTest(@"(waterlevel > 1 AND waterlevel <= 3)", false, 3.1);
             ExecuteTest(@"(waterlevel > 3 AND waterlevel <= 5)", true, 3.1);
-            // ExecuteTest(@"(3 < waterlevel AND 5 >= waterlevel)", true, 3.1);
-            // ExecuteTest(@"(3.2 < waterlevel AND 5.3 >= waterlevel)", true, 4);
+            ExecuteTest(@"(3 < waterlevel AND 5 >= waterlevel)", true, 3.1);
+            ExecuteTest(@"(3.2 < waterlevel AND 5.3 >= waterlevel)", true, 4);
 
             void ExecuteTest(string expression, bool expected, double inputValue)
             {

--- a/test/NCalc.Tests/Fixtures.cs
+++ b/test/NCalc.Tests/Fixtures.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.Linq;
 using BinaryExpression = NCalc.Domain.BinaryExpression;
 using UnaryExpression = NCalc.Domain.UnaryExpression;
+using Newtonsoft.Json;
 
 namespace NCalc.Tests
 {
@@ -1145,6 +1146,56 @@ namespace NCalc.Tests
                 }.Evaluate());
 
             }
+        }
+
+        // [Theory]
+        // [InlineData(@"(level > 1 AND level <= 3)", false, 3.2)]
+        // [InlineData(@"(level > 3 AND level <= 5)", true, 3.2)]
+        // [InlineData(@"(level > 1 AND level <= 3)", false, 3.1)]
+        // [InlineData(@"(level > 3 AND level <= 5)", true, 3.1)]
+        // [InlineData(@"(3 < level AND 5 >= level)", true, 3.1)]
+        // [InlineData(@"(3.2 < level AND 5.3 >= level)", true, 4)]
+        [TestMethod]
+        public void SerializeAndDeserialize_ShouldWork()
+        {
+            
+            ExecuteTest(@"(waterlevel > 1 AND waterlevel <= 3)", false, 3.2);
+            ExecuteTest(@"(waterlevel > 3 AND waterlevel <= 5)", true, 3.2);
+            ExecuteTest(@"(waterlevel > 1 AND waterlevel <= 3)", false, 3.1);
+            ExecuteTest(@"(waterlevel > 3 AND waterlevel <= 5)", true, 3.1);
+            // ExecuteTest(@"(3 < waterlevel AND 5 >= waterlevel)", true, 3.1);
+            // ExecuteTest(@"(3.2 < waterlevel AND 5.3 >= waterlevel)", true, 4);
+
+            void ExecuteTest(string expression, bool expected, double inputValue)
+            {
+                var compiled = Expression.Compile(expression, true);
+                var serialized = JsonConvert.SerializeObject(compiled, new JsonSerializerSettings
+                {
+                    TypeNameHandling = TypeNameHandling.All // We need this to allow serializing abstract classes
+                });
+
+                var deserialized = JsonConvert.DeserializeObject<LogicalExpression>(serialized, new JsonSerializerSettings
+                {
+                    TypeNameHandling = TypeNameHandling.All
+                });
+
+                Expression.CacheEnabled = false;
+                var exp = new Expression(deserialized);
+                exp.Parameters = new Dictionary<string, object> {
+                    {"waterlevel", inputValue}
+                };
+
+                object evaluated;
+                try {
+                    evaluated = exp.Evaluate();
+                } catch {
+                    evaluated = false;
+                }
+
+                // Assert
+                Assert.AreEqual(evaluated, expected, expression);
+            }
+
         }
     }
 }

--- a/test/NCalc.Tests/NCalc.Tests.csproj
+++ b/test/NCalc.Tests/NCalc.Tests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
As mentioned in my issue, this PR fixes the order of the CommonTypes to consider Double before an Int64. This may have some cost on the performance and we may want to revisit how the type detection works in the future.

I have also added an example to the README of how to use this with a distributed cache (eg, Redis).