### PR TITLE
Added EvaluateOptions.CaseInsensitiveComparer

### DIFF
--- a/src/NCalc/EvaluationOption.cs
+++ b/src/NCalc/EvaluationOption.cs
@@ -25,6 +25,11 @@ namespace NCalc
         //
         // Summary:
         //     When using Round(), if a number is halfway between two others, it is rounded toward the nearest number that is away from zero. 
-        RoundAwayFromZero = 16
+        RoundAwayFromZero = 16,
+        
+        //
+        // Summary:
+        //     Specifies the use of CaseInsensitiveComparer for comparasions.
+        CaseInsensitiveComparer = 32
     }
 }

--- a/src/NCalc/Expression.cs
+++ b/src/NCalc/Expression.cs
@@ -14,16 +14,16 @@ namespace NCalc
     public class Expression
     {
         public EvaluateOptions Options { get; set; }
-
+        
         /// <summary>
         /// Textual representation of the expression to evaluate.
         /// </summary>
-        protected string OriginalExpression;
+        protected string OriginalExpression { get; set; }
 
         /// <summary>
-        /// Get or set the culture info
+        /// Get or set the culture info.
         /// </summary>
-        protected CultureInfo CultureInfo;
+        protected CultureInfo CultureInfo { get; set; }
 
         public Expression(string expression) : this(expression, EvaluateOptions.None, CultureInfo.CurrentCulture)
         {
@@ -126,10 +126,9 @@ namespace NCalc
                 {
                     Rwl.AcquireReaderLock(Timeout.Infinite);
 
-                    if (_compiledExpressions.ContainsKey(expression))
+                    if (_compiledExpressions.TryGetValue(expression, out var wr))
                     {
                         Trace.TraceInformation("Expression retrieved from cache: " + expression);
-                        var wr = _compiledExpressions[expression];
                         logicalExpression = wr.Target as LogicalExpression;
 
                         if (wr.IsAlive && logicalExpression != null)
@@ -324,9 +323,8 @@ namespace NCalc
 
         public Dictionary<string, object> Parameters
         {
-            get { return _parameters ?? (_parameters = new Dictionary<string, object>()); }
-            set { _parameters = value; }
+            get => _parameters ?? (_parameters = new Dictionary<string, object>());
+            set => _parameters = value;
         }
-
     }
 }

--- a/test/NCalc.Tests/Fixtures.cs
+++ b/test/NCalc.Tests/Fixtures.cs
@@ -1188,7 +1188,15 @@ namespace NCalc.Tests
                 // Assert
                 Assert.AreEqual(evaluated, expected, expression);
             }
+        }
+        
+        [TestMethod]
+        public void Should_Use_Case_Insensitive_Comparer_Issue_85()
+        {
+            var eif = new Expression("PageState == 'LIST'", EvaluateOptions.CaseInsensitiveComparer);
+            eif.Parameters["PageState"] = "List";
 
+            Assert.AreEqual(true, eif.Evaluate());
         }
     }
 }


### PR DESCRIPTION
This closes #85 

I'm using `EvaluateOptions.CaseInsensitiveComparer` because there is no `Comparer` classes to cover all scenarios from the `StringComparer` enum.

Also applied some suggestions from the Rider editor at the codebase.