### PR TITLE
Add support for ifs(cond, val, default)

### DIFF
--- a/src/NCalc/Domain/EvaluationVisitor.cs
+++ b/src/NCalc/Domain/EvaluationVisitor.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 
 namespace NCalc.Domain;
 
@@ -594,6 +595,31 @@ public class EvaluationVisitor(EvaluateOptions options, CultureInfo cultureInfo)
 
             #endregion
 
+            #region ifs
+            case string n when n.Equals("ifs", StringComparison.OrdinalIgnoreCase):
+
+                CheckCase("ifs", function.Identifier.Name);
+                object result = null;
+
+                if (function.Expressions.Length < 3 || function.Expressions.Length % 2 != 1)
+                    throw new ArgumentException("ifs() takes at least 3 arguments, or an odd number of arguments");
+
+                foreach (var eval in function.Expressions.Where((_, i) => i % 2 == 0))
+                {
+                    var index = Array.IndexOf(function.Expressions, eval);
+                    var tf = Convert.ToBoolean(Evaluate(eval), cultureInfo);
+                    if (index == function.Expressions.Length - 1)
+                        Result = Evaluate(eval);
+                    else if (tf)
+                    {
+                        Result = Evaluate(function.Expressions[index + 1]);
+                        break;
+                    }
+                }
+
+                break;
+
+            #endregion
             #region if
             case string n when n.Equals("if", StringComparison.OrdinalIgnoreCase):
 
@@ -608,6 +634,7 @@ public class EvaluationVisitor(EvaluateOptions options, CultureInfo cultureInfo)
                 break;
 
             #endregion
+
 
             #region in
             case string n when n.Equals("in", StringComparison.OrdinalIgnoreCase):

--- a/src/NCalc/Domain/EvaluationVisitor.cs
+++ b/src/NCalc/Domain/EvaluationVisitor.cs
@@ -599,7 +599,6 @@ public class EvaluationVisitor(EvaluateOptions options, CultureInfo cultureInfo)
             case string n when n.Equals("ifs", StringComparison.OrdinalIgnoreCase):
 
                 CheckCase("ifs", function.Identifier.Name);
-                object result = null;
 
                 if (function.Expressions.Length < 3 || function.Expressions.Length % 2 != 1)
                     throw new ArgumentException("ifs() takes at least 3 arguments, or an odd number of arguments");

--- a/test/NCalc.Tests/Fixtures.cs
+++ b/test/NCalc.Tests/Fixtures.cs
@@ -173,7 +173,7 @@ namespace NCalc.Tests
         }
 
         [TestMethod]
-        public void ShouldEvaluateConditionnal()
+        public void ShouldEvaluateConditional()
         {
             var eif = new Expression("if([divider] <> 0, [divided] / [divider], 0)");
             eif.Parameters["divider"] = 5;
@@ -1197,6 +1197,46 @@ namespace NCalc.Tests
             eif.Parameters["PageState"] = "List";
 
             Assert.AreEqual(true, eif.Evaluate());
+        }
+
+        [TestMethod]
+        public void Should_Evaluate_Ifs()
+        {
+            // Test first case true, return next value
+            var eifs = new Expression("ifs([divider] != 0, [divided] / [divider], -1)");
+            eifs.Parameters["divider"] = 5;
+            eifs.Parameters["divided"] = 5;
+
+            Assert.AreEqual(1d, eifs.Evaluate());
+
+            // Test first case false, no next case, return default value
+            eifs = new Expression("ifs([divider] != 0, [divided] / [divider], -1)");
+            eifs.Parameters["divider"] = 0;
+            eifs.Parameters["divided"] = 5;
+
+            Assert.AreEqual(-1, eifs.Evaluate());
+
+            // Test first case false, next case true, return next value (eg 4th expr)
+
+            eifs = new Expression("ifs([number] == 3, 5, [number] == 5, 3, 8)");
+            eifs.Parameters["number"] = 5;
+            Assert.AreEqual(3, eifs.Evaluate());
+
+            // Test first case false, next case false, return default value (eg 5th expr)
+
+            eifs = new Expression("ifs([number] == 3, 5, [number] == 5, 3, 8)");
+            eifs.Parameters["number"] = 1337;
+
+            Assert.AreEqual(8, eifs.Evaluate());
+        }
+
+        [TestMethod]
+        public void Ifs_With_Improper_Arguments_Should_Throw_Exceptions()
+        {
+            Assert.ThrowsException<ArgumentException>(() => new Expression("ifs()").Evaluate());
+            Assert.ThrowsException<ArgumentException>(() => new Expression("ifs([divider] > 0)").Evaluate());
+            Assert.ThrowsException<ArgumentException>(() => new Expression("ifs([divider] > 0, [divider] / [divided])").Evaluate());
+            Assert.ThrowsException<ArgumentException>(() => new Expression("ifs([divider] > 0, [divider] / [divided], [divider < 0], [divider] + [divided])").Evaluate());
         }
     }
 }


### PR DESCRIPTION
This PR adds support for  a new function`ifs()`, similar to `if()` but allows an arbitrary collection of `(condition, value)` pairs along with a default value if none of the conditions evaluate to true.

Examples:

`ifs([divider] != 0, [divided] / [divider], -1)` -> if `divider` != 0, return the value of `[divided] / [divider]`, otherwise return -1

I added unit tests for this as well, let me know if you think they need to be more comprehensive.
