### PR TITLE
Make EvaluationVisitor sub-class friendly

### DIFF
--- a/src/NCalc/Domain/EvaluationVisitor.cs
+++ b/src/NCalc/Domain/EvaluationVisitor.cs
@@ -689,10 +689,9 @@ public class EvaluationVisitor(EvaluateOptions options, CultureInfo cultureInfo)
 
     public event EvaluateFunctionHandler EvaluateFunction;
 
-    private void OnEvaluateFunction(string name, FunctionArgs args)
+    protected void OnEvaluateFunction(string name, FunctionArgs args)
     {
-        if (EvaluateFunction != null)
-            EvaluateFunction(name, args);
+        EvaluateFunction?.Invoke(name, args);
     }
 
     public override void Visit(Identifier parameter)
@@ -736,7 +735,7 @@ public class EvaluationVisitor(EvaluateOptions options, CultureInfo cultureInfo)
 
     public event EvaluateParameterHandler EvaluateParameter;
 
-    private void OnEvaluateParameter(string name, ParameterArgs args)
+    protected void OnEvaluateParameter(string name, ParameterArgs args)
     {
         EvaluateParameter?.Invoke(name, args);
     }

--- a/src/NCalc/Expression.cs
+++ b/src/NCalc/Expression.cs
@@ -18,7 +18,7 @@ public class Expression
     /// <summary>
     /// Textual representation of the expression to evaluate.
     /// </summary>
-    protected string OriginalExpression { get; set; }
+    public string OriginalExpression { get; protected set; }
 
     /// <summary>
     /// Get or set the culture info.


### PR DESCRIPTION
OnEvaluateParameters and OnEvaluateFunction to be changed to protected (from private), otherwise there's no way to invoke the handlers from a sub-class (since you can't raise the parent event).

Also adding public access to the original string expression and moving to protected set. This is a convenience over having to compile the expression and then call ToString() on Expression just for a string representation.