### PR TITLE
ignore build result files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /.axoCover
 /.temp
 *.bak
+bin/
+obj/


### PR DESCRIPTION
.gitignore changed to ignore build result files in folder 'obj' and 'bin'