### PR TITLE
Add support for comparison with null parameters

### DIFF
--- a/docs/articles/parameters.md
+++ b/docs/articles/parameters.md
@@ -76,7 +76,7 @@ When parameter is null and **EvaluationOptions.AllowNullParameter** is used, com
 
 ```c#
 Expression e = new Expression("'a string' == null", ExpressionOptions.AllowNullParameter);
-(bool)e.Evaluate()
+(bool)e.Evaluate();
 
  //  False
 ```

--- a/docs/articles/parameters.md
+++ b/docs/articles/parameters.md
@@ -71,6 +71,16 @@ When parameters are IEnumerable and the **EvaluationOptions.IterateParameters** 
  //  0
 ```
 
+## Compare with null parameters
+When parameter is null and **EvaluationOptions.AllowNullParameter** is used, comparison of values to null is allowed.
+
+```c#
+Expression e = new Expression("'a string' == null", ExpressionOptions.AllowNullParameter);
+(bool)e.Evaluate()
+
+ //  False
+```
+
 ## Getting all parameters from an expression
 
 ```c#

--- a/src/NCalc/Expression.cs
+++ b/src/NCalc/Expression.cs
@@ -134,6 +134,9 @@ public class Expression
         if (HasErrors() && Error is not null)
             throw Error;
 
+        if (Options.HasOption(ExpressionOptions.AllowNullParameter))
+            EvaluationVisitor.Parameters["null"] = null;
+
         // If array evaluation, execute the same expression multiple times
         if (Options.HasOption(ExpressionOptions.IterateParameters))
             return IterateParameters();

--- a/src/NCalc/ExpressionOptions.cs
+++ b/src/NCalc/ExpressionOptions.cs
@@ -5,37 +5,42 @@ public enum ExpressionOptions
 {
     // Summary:
     //     Specifies that no options are set.
-    None = 1,
+    None = 1 << 0,
 
     //
     // Summary:
     //     Specifies case-insensitive matching.
-    IgnoreCase = 2,
+    IgnoreCase = 1 << 1,
 
     //
     // Summary:
     //     No-cache mode. Ingores any pre-compiled expression in the cache.
-    NoCache = 4,
+    NoCache = 1 << 2,
 
     //
     // Summary:
     //     Treats parameters as arrays and result a set of results.
-    IterateParameters = 8,
+    IterateParameters = 1 << 3,
 
     //
     // Summary:
     //     When using Round(), if a number is halfway between two others, it is rounded toward the nearest number that is away from zero. 
-    RoundAwayFromZero = 16,
+    RoundAwayFromZero = 1 << 4,
 
     //
     // Summary:
     //     Specifies the use of CaseInsensitiveComparer for comparasions.
-    CaseInsensitiveComparer = 32,
+    CaseInsensitiveComparer = 1 << 5,
 
     //
     // Summary:
     //     Uses decimals instead of doubles as default floating point data type
-    DecimalAsDefault = 64
+    DecimalAsDefault = 1 << 6,
+
+    /// <summary>
+    /// Defines a "null" parameter and allows comparison of values to null.
+    /// </summary>
+    AllowNullParameter = 1 << 7
 }
 
 // Summary:

--- a/test/NCalc.Tests/ComparerTests.cs
+++ b/test/NCalc.Tests/ComparerTests.cs
@@ -29,4 +29,73 @@ public class ComparerTests
 
         Assert.Equal(expectedResult, (bool)issueExp.Evaluate());
     }
+
+    [Fact]
+    public void ExpressionShouldHandleNullRightParameters()
+    {
+        var e = new Expression("'a string' == null", ExpressionOptions.AllowNullParameter);
+        Assert.False((bool)e.Evaluate());
+    }
+
+    [Fact]
+    public void ExpressionShouldHandleNullLeftParameters()
+    {
+        var e = new Expression("null == 'a string'", ExpressionOptions.AllowNullParameter);
+        Assert.False((bool)e.Evaluate());
+    }
+
+    [Fact]
+    public void ExpressionShouldHandleNullBothParameters()
+    {
+        var e = new Expression("null == null", ExpressionOptions.AllowNullParameter);
+        Assert.True((bool)e.Evaluate());
+    }
+
+    [Fact]
+    public void ShouldCompareNullToNull()
+    {
+        var e = new Expression("[x] = null", ExpressionOptions.AllowNullParameter);
+        e.Parameters["x"] = null;
+
+        Assert.True((bool)e.Evaluate());
+    }
+
+    [Fact]
+    public void ShouldCompareNullableToNonNullable()
+    {
+        var e = new Expression("[x] = 5", ExpressionOptions.AllowNullParameter);
+
+        e.Parameters["x"] = (int?)5;
+        Assert.True((bool)e.Evaluate());
+
+        e.Parameters["x"] = (int?)6;
+        Assert.False((bool)e.Evaluate());
+    }
+
+    [Fact]
+    public void ShouldCompareNullableNullToNonNullable()
+    {
+        var e = new Expression("[x] = 5", ExpressionOptions.AllowNullParameter);
+
+        e.Parameters["x"] = null;
+        Assert.False((bool)e.Evaluate());
+    }
+
+    [Fact]
+    public void ShouldCompareNullToString()
+    {
+        var e = new Expression("[x] = 'foo'", ExpressionOptions.AllowNullParameter);
+        e.Parameters["x"] = null;
+
+        Assert.False((bool)e.Evaluate());
+    }
+
+    [Fact]
+    public void ExpressionDoesNotDefineNullParameterWithoutNullOption()
+    {
+        var e = new Expression("'a string' == null");
+
+        var ex = Assert.Throws<ArgumentException>(() => e.Evaluate());
+        Assert.Contains("Parameter was not defined", ex.Message);
+    }
 }


### PR DESCRIPTION
This PR adds support for comparision with null parameters. To compare with null you should use ExpressionOptions.AllowNullParameter

Closes #153