### PR TITLE
Added support for using semicolon as argument separator

### DIFF
--- a/docs/articles/functions.md
+++ b/docs/articles/functions.md
@@ -32,3 +32,5 @@ It also includes other general purpose ones.
 |in	|Returns whether an element is in a set of values.	|in(1 + 1, 1, 2, 3)	|true|
 |if	|Returns a value based on a condition.	|if(3 % 2 = 1, 'value is true', 'value is false')	|'value is true'|
 |ifs    |Returns a value based on evaluating a number of conditions, returning a default if none are true. | ifs(foo > 50, "bar", foo > 75, "baz", "quux") | if foo is between 50 and 75 "bar", foo greater than 75 "baz", otherwise "quux" |  
+
+You can use comma (,) or semicolon (;) for argmument separator.

--- a/src/NCalc/Parser/LogicalExpressionParser.cs
+++ b/src/NCalc/Parser/LogicalExpressionParser.cs
@@ -36,7 +36,7 @@ public static class LogicalExpressionParser
          *                  | "(" expression ")" ;
          *
          * function       => Identifier "(" arguments ")"
-         * arguments      => expression ( "," expression )*
+         * arguments      => expression ( ("," | ";") expression )*
          */
         // The Deferred helper creates a parser that can be referenced by others before it is defined
         var expression = Deferred<LogicalExpression>();
@@ -104,6 +104,7 @@ public static class LogicalExpressionParser
         var closeBrace = Terms.Char(']');
         var questionMark = Terms.Char('?');
         var colon = Terms.Char(':');
+        var semicolon = Terms.Char(';');
         
         var negate = Terms.Text("!");
         var not = Terms.Text("not", true);
@@ -117,7 +118,7 @@ public static class LogicalExpressionParser
             .Or(Terms.Identifier())
             .Then<LogicalExpression>(x => new Identifier(x.ToString()));
 
-        var arguments = Separated(comma, expression);
+        var arguments = Separated(comma.Or(semicolon), expression);
 
         var functionWithArguments = Terms
             .Identifier()

--- a/test/NCalc.Tests/EvaluationTests.cs
+++ b/test/NCalc.Tests/EvaluationTests.cs
@@ -172,4 +172,14 @@ public class EvaluationTests
 
         Assert.Equal(6, volume.Evaluate());
     }
+
+    [Theory]
+    [InlineData("Round(1.412; 2)", 1.41)]
+    [InlineData("Max(5.1; 10.2)", 10.2)]
+    [InlineData("Min(1.3; 2)", 1.3)]
+    [InlineData("Pow(5;2)", 25)]
+    public void ShouldAllowSemicolonAsArgumentSeparator(string expression, object expected)
+    {
+        Assert.Equal(expected, new Expression(expression).Evaluate());
+    }
 }


### PR DESCRIPTION
Added support for using semicolon as argument separator. This PR is a part of using culture-specific decimal number separator. If comma is decimal separator it'll be more readable if semicolon is used (e.g. "Round(1,23;1)")