### PR TITLE
Fix handling invalid token

### DIFF
--- a/src/NCalc/Parser/LogicalExpressionParser.cs
+++ b/src/NCalc/Parser/LogicalExpressionParser.cs
@@ -1,5 +1,4 @@
 using NCalc.Domain;
-using NCalc.Exceptions;
 using Parlot.Fluent;
 using static Parlot.Fluent.Parsers;
 using Identifier = NCalc.Domain.Identifier;

--- a/test/NCalc.Tests/ExceptionsTests.cs
+++ b/test/NCalc.Tests/ExceptionsTests.cs
@@ -19,6 +19,9 @@ public class ExceptionsTests
     [Theory]
     [InlineData(". + 2")]
     [InlineData("(3 + 2")]
+    [InlineData("42a")]
+    [InlineData("42.3a")]
+    [InlineData("42.3e-5a")]
     public void Should_Throw_Parse_Exception(string expression)
     {
         Assert.Throws<NCalcParserException>(() =>new Expression(expression).Evaluate());

--- a/test/NCalc.Tests/ExceptionsTests.cs
+++ b/test/NCalc.Tests/ExceptionsTests.cs
@@ -20,7 +20,9 @@ public class ExceptionsTests
     [InlineData(". + 2")]
     [InlineData("(3 + 2")]
     [InlineData("42a")]
+    [InlineData("42a.3")]
     [InlineData("42.3a")]
+    [InlineData("42a.3b")]
     [InlineData("42.3e-5a")]
     public void Should_Throw_Parse_Exception(string expression)
     {


### PR DESCRIPTION
This PR fixes using invalid tokens inside expression.

Closes #150

Though, all tests are passing I don't like the implementation. For some reason such expression is not working:

`.AndSkip(Literals.Identifier().Error("Invalid token in expression"))`

@gumbarros, do you have ideas why it's not working?