### PR TITLE
Move `Type` logic to `TypeHelper` and improve exception handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # 4.2
 * [Improve Parlot error handling](https://github.com/ncalc/ncalc/pull/181) by [Andrey Bykiev](https://github.com/Bykiev)
-
 ## Breaking Changes
 * [Do not convert external function name to lower case when ExpressionOptions.IgnoreCase option is used](https://github.com/ncalc/ncalc/pull/179) by [Andrey Bykiev](https://github.com/Bykiev)
 * [Add support for using null with operators](https://github.com/ncalc/ncalc/pull/184) by [Andrey Bykiev](https://github.com/Bykiev)
+* [Exceptions need to be handled as NCalcEvaluationException instead of ArgumentException and added TypeHelper](https://github.com/ncalc/ncalc/pull/182) by [Gustavo Barros](https://github.com/gumbarros)
 
 # 4.1
 * [Remove excessive check for casing](https://github.com/ncalc/ncalc/pull/149) by [Andrey Bykiev](https://github.com/Bykiev)

--- a/src/NCalc/Exceptions/NCalcEvaluationException.cs
+++ b/src/NCalc/Exceptions/NCalcEvaluationException.cs
@@ -1,14 +1,3 @@
 ﻿namespace NCalc.Exceptions;
 
-public sealed class NCalcEvaluationException : NCalcException
-{
-    public NCalcEvaluationException(string message)
-        : base(message)
-    {
-    }
-
-    public NCalcEvaluationException(string message, Exception innerException)
-        : base(message, innerException)
-    {
-    }
-}
+public class NCalcEvaluationException(string message) : NCalcException(message);

--- a/src/NCalc/Exceptions/NCalcFunctionNotFoundException.cs
+++ b/src/NCalc/Exceptions/NCalcFunctionNotFoundException.cs
@@ -1,0 +1,7 @@
+﻿namespace NCalc.Exceptions;
+
+public sealed class NCalcFunctionNotFoundException(string message, string functionName) 
+    : NCalcEvaluationException(message)
+{
+    public string FunctionName { get;} = functionName;
+}

--- a/src/NCalc/Exceptions/NCalcParameterNotDefinedException.cs
+++ b/src/NCalc/Exceptions/NCalcParameterNotDefinedException.cs
@@ -1,0 +1,7 @@
+﻿namespace NCalc.Exceptions;
+
+public sealed class NCalcParameterNotDefinedException(string parameterName)
+    : NCalcEvaluationException($"Parameter {parameterName} not defined.")
+{
+    public string ParameterName { get; } = parameterName;
+}

--- a/src/NCalc/Exceptions/NCalcParameterNotFoundException.cs
+++ b/src/NCalc/Exceptions/NCalcParameterNotFoundException.cs
@@ -1,0 +1,7 @@
+﻿namespace NCalc.Exceptions;
+
+public sealed class NCalcParameterNotFoundException(string parameterName)
+    : NCalcEvaluationException($"Parameter {parameterName} not found.")
+{
+    public string ParameterName { get; } = parameterName;
+}

--- a/src/NCalc/Exceptions/NCalcParameterNotFoundException.cs
+++ b/src/NCalc/Exceptions/NCalcParameterNotFoundException.cs
@@ -1,7 +1,0 @@
-﻿namespace NCalc.Exceptions;
-
-public sealed class NCalcParameterNotFoundException(string parameterName)
-    : NCalcEvaluationException($"Parameter {parameterName} not found.")
-{
-    public string ParameterName { get; } = parameterName;
-}

--- a/src/NCalc/Expression.cs
+++ b/src/NCalc/Expression.cs
@@ -244,7 +244,7 @@ public class Expression
                 }
                 else if (localsize != size)
                 {
-                    throw new NCalcEvaluationException("When IterateParameters option is used, IEnumerable parameters must have the same number of items");
+                    throw new NCalcException("When IterateParameters option is used, IEnumerable parameters must have the same number of items");
                 }
             }
         }

--- a/src/NCalc/Helpers/TypeHelper.cs
+++ b/src/NCalc/Helpers/TypeHelper.cs
@@ -1,0 +1,60 @@
+﻿namespace NCalc.Helpers;
+
+public static class TypeHelper
+{
+    private static readonly Type[] BuiltInTypes =
+    [
+        typeof(decimal),
+        typeof(double),
+        typeof(float),
+        typeof(long),
+        typeof(ulong),
+        typeof(int),
+        typeof(uint),
+        typeof(short),
+        typeof(ushort),
+        typeof(byte),
+        typeof(sbyte),
+        typeof(char),
+        typeof(bool),
+        typeof(string),
+        typeof(object)
+    ];
+    
+    /// <summary>
+    /// Gets the the most precise type.
+    /// </summary>
+    /// <param name="a">Type a.</param>
+    /// <param name="b">Type b.</param>
+    /// <returns></returns>
+    private static Type GetMostPreciseType(Type? a, Type? b)
+    {
+        foreach (var t in BuiltInTypes)
+        {
+            if (a == t || b == t)
+            {
+                return t;
+            }
+        }
+
+        return a ?? typeof(object);
+    }
+    
+    public static bool IsReal(object? value) => value is decimal or double or float;
+
+    public record struct ComparasionOptions(CultureInfo CultureInfo, bool IsCaseSensitive);
+    public static int CompareUsingMostPreciseType(object? a, object? b, ComparasionOptions options)
+    {
+        var (cultureInfo, isCaseInsensitiveComparer) = options;
+
+        var mpt = GetMostPreciseType(a?.GetType(), b?.GetType());
+
+        var aValue = a != null ? Convert.ChangeType(a, mpt, cultureInfo) : null;
+        var bValue = b != null ? Convert.ChangeType(b, mpt, cultureInfo) : null;
+
+        if (isCaseInsensitiveComparer)
+            return CaseInsensitiveComparer.Default.Compare(aValue, bValue);
+
+        return Comparer.Default.Compare(aValue, bValue);
+    }
+}

--- a/src/NCalc/Visitors/Abstractions/ILogicalExpressionVisitor.cs
+++ b/src/NCalc/Visitors/Abstractions/ILogicalExpressionVisitor.cs
@@ -11,5 +11,5 @@ public interface ILogicalExpressionVisitor
     public void Visit(UnaryExpression expression);
     public void Visit(ValueExpression expression);
     public void Visit(Function function);
-    public void Visit(Identifier function);
+    public void Visit(Identifier identifier);
 }

--- a/src/NCalc/Visitors/Abstractions/LogicalExpressionVisitor.cs
+++ b/src/NCalc/Visitors/Abstractions/LogicalExpressionVisitor.cs
@@ -11,5 +11,5 @@ public abstract class LogicalExpressionVisitor : ILogicalExpressionVisitor
     public abstract void Visit(UnaryExpression expression);
     public abstract void Visit(ValueExpression expression);
     public abstract void Visit(Function function);
-    public abstract void Visit(Identifier function);
+    public abstract void Visit(Identifier identifier);
 }

--- a/src/NCalc/Visitors/EvaluationVisitor.cs
+++ b/src/NCalc/Visitors/EvaluationVisitor.cs
@@ -522,7 +522,7 @@ public class EvaluationVisitor : IEvaluationVisitor
             OnEvaluateParameter(identifier.Name, args);
 
             if (!args.HasResult)
-                throw new NCalcParameterNotFoundException(identifier.Name);
+                throw new NCalcParameterNotDefinedException(identifier.Name);
 
             Result = args.Result;
         }

--- a/src/NCalc/Visitors/SerializationVisitor.cs
+++ b/src/NCalc/Visitors/SerializationVisitor.cs
@@ -181,9 +181,9 @@ public class SerializationVisitor : ILogicalExpressionVisitor
         Result.Append(") ");
     }
 
-    public void Visit(Identifier parameter)
+    public void Visit(Identifier identifier)
     {
-        Result.Append('[').Append(parameter.Name).Append("] ");
+        Result.Append('[').Append(identifier.Name).Append("] ");
     }
 
     protected virtual void EncapsulateNoValue(LogicalExpression expression)

--- a/test/NCalc.Tests/ComparerTests.cs
+++ b/test/NCalc.Tests/ComparerTests.cs
@@ -1,3 +1,5 @@
+using NCalc.Exceptions;
+
 namespace NCalc.Tests;
 
 [Trait("Category","Comparer")]
@@ -95,7 +97,7 @@ public class ComparerTests
     {
         var e = new Expression("'a string' == null");
 
-        var ex = Assert.Throws<ArgumentException>(() => e.Evaluate());
-        Assert.Contains("Parameter was not defined", ex.Message);
+        var ex = Assert.Throws<NCalcParameterNotDefinedException>(() => e.Evaluate());
+        Assert.Contains("not defined", ex.Message);
     }
 }

--- a/test/NCalc.Tests/EvaluationTests.cs
+++ b/test/NCalc.Tests/EvaluationTests.cs
@@ -1,3 +1,4 @@
+using NCalc.Exceptions;
 using NCalc.Tests.TestData;
 
 namespace NCalc.Tests;
@@ -129,7 +130,7 @@ public class EvaluationTests
         Assert.Equal(1M, new Expression("aBs(-1)", ExpressionOptions.IgnoreCase).Evaluate());
         Assert.Equal(1M, new Expression("Abs(-1)").Evaluate());
 
-        Assert.Throws<ArgumentException>(() => new Expression("aBs(-1)").Evaluate());
+        Assert.Throws<NCalcFunctionNotFoundException>(() => new Expression("aBs(-1)").Evaluate());
     }
 
     [Fact]

--- a/test/NCalc.Tests/ExceptionsTests.cs
+++ b/test/NCalc.Tests/ExceptionsTests.cs
@@ -13,7 +13,7 @@ public class ExceptionsTests
     [InlineData("ifs([divider] > 0, [divider] / [divided], [divider < 0], [divider] + [divided])")]
     public void Ifs_With_Improper_Arguments_Should_Throw_Exceptions(string expression)
     {
-        Assert.Throws<ArgumentException>(() => new Expression(expression).Evaluate());
+        Assert.Throws<NCalcEvaluationException>(() => new Expression(expression).Evaluate());
     }
 
     [Theory]
@@ -109,7 +109,7 @@ public class ExceptionsTests
     public void Should_Throw_Parameter_Not_Found()
     {
         var expression = new Expression("{Name} == 'Spinella'");
-        var exception = Assert.Throws<NCalcParameterNotFoundException>(() => expression.Evaluate());
+        var exception = Assert.Throws<NCalcParameterNotDefinedException>(() => expression.Evaluate());
         Assert.Equal("Name",exception.ParameterName);
     }
 }

--- a/test/NCalc.Tests/ExceptionsTests.cs
+++ b/test/NCalc.Tests/ExceptionsTests.cs
@@ -96,4 +96,20 @@ public class ExceptionsTests
             Assert.Equal("Invalid token in expression at position (1:3)", ex.InnerException.Message);
         }
     }
+    
+    [Fact]
+    public void Should_Throw_Function_Not_Found()
+    {
+        var expression = new Expression("drop_database()");
+        var exception = Assert.Throws<NCalcFunctionNotFoundException>(() => expression.Evaluate());
+        Assert.Equal("drop_database",exception.FunctionName);
+    }
+    
+    [Fact]
+    public void Should_Throw_Parameter_Not_Found()
+    {
+        var expression = new Expression("{Name} == 'Spinella'");
+        var exception = Assert.Throws<NCalcParameterNotFoundException>(() => expression.Evaluate());
+        Assert.Equal("Name",exception.ParameterName);
+    }
 }

--- a/test/NCalc.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/NCalc.Tests/ServiceCollectionExtensionsTests.cs
@@ -160,7 +160,7 @@ public class ServiceCollectionExtensionsTests
             throw new NotImplementedException();
         }
 
-        public void Visit(Identifier function)
+        public void Visit(Identifier identifier)
         {
             throw new NotImplementedException();
         }
@@ -204,7 +204,7 @@ public class ServiceCollectionExtensionsTests
             throw new NotImplementedException();
         }
 
-        public void Visit(Identifier function)
+        public void Visit(Identifier identifier)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
Small refactors.

- Improve exception handling (#175) with two new exceptions (`NCalcParameterNotDefinedException`, `NCalcFunctionNotFoundException`) and use `NCalcEvaluationException` instead of `ArgumentException`
- Starting to remove some logic from `EvalutationVisitor` so it can be used at `async` (#172 )