### PR TITLE
Add support for using null with operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Breaking Changes
 * [Do not convert external function name to lower case when ExpressionOptions.IgnoreCase option is used](https://github.com/ncalc/ncalc/pull/179) by [Andrey Bykiev](https://github.com/Bykiev)
+* [Add support for using null with operators](https://github.com/ncalc/ncalc/pull/184) by [Andrey Bykiev](https://github.com/Bykiev)
 
 # 4.1
 * [Remove excessive check for casing](https://github.com/ncalc/ncalc/pull/149) by [Andrey Bykiev](https://github.com/Bykiev)

--- a/src/NCalc/Helpers/MathHelper.cs
+++ b/src/NCalc/Helpers/MathHelper.cs
@@ -10,16 +10,19 @@ public static class MathHelper
         return s is string or char ? decimal.Parse(s.ToString()!, cultureInfo) : s;
     }
 
-    public static object Add(object? a, object? b)
+    public static object? Add(object? a, object? b)
     {
         return Add(a, b, CultureInfo.CurrentCulture);
     }
 
-    public static object Add(object? a, object? b, CultureInfo cultureInfo)
+    public static object? Add(object? a, object? b, CultureInfo cultureInfo)
     {
+        if (a == null || b == null)
+            return null;
+
         a = ConvertIfString(a, cultureInfo);
         b = ConvertIfString(b, cultureInfo);
-        
+
         switch (a)
         {
             case bool:
@@ -217,19 +220,22 @@ public static class MathHelper
         }
     }
 
-    public static object Subtract(object? a, object? b)
+    public static object? Subtract(object? a, object? b)
     {
         return Subtract(a, b, CultureInfo.CurrentCulture);
     }
 
-    public static object Subtract(object? a, object? b, CultureInfo cultureInfo)
+    public static object? Subtract(object? a, object? b, CultureInfo cultureInfo)
     {
+        if (a == null || b == null)
+            return null;
+
         a = ConvertIfString(a, cultureInfo);
         b = ConvertIfString(b, cultureInfo);
 
         switch (a)
         {
-            case bool: 
+            case bool:
                 throw new InvalidOperationException($"Operator '-' can't be applied to operands of types 'bool' and {b?.GetType()}");
             case byte b1:
                 switch (b)
@@ -423,17 +429,18 @@ public static class MathHelper
         }
     }
 
-    public static object Multiply(object? a, object? b)
+    public static object? Multiply(object? a, object? b)
     {
         return Multiply(a, b, CultureInfo.CurrentCulture);
     }
 
-    public static object Multiply(object? a, object? b, CultureInfo cultureInfo)
+    public static object? Multiply(object? a, object? b, CultureInfo cultureInfo)
     {
+        if (a == null || b == null)
+            return null;
+
         a = ConvertIfString(a, cultureInfo);
         b = ConvertIfString(b, cultureInfo);
-
-
 
         switch (a)
         {
@@ -594,7 +601,7 @@ public static class MathHelper
                     case decimal @decimal: return Convert.ToDecimal(a) * @decimal;
                     default: throw new InvalidOperationException($"Operator '*' not implemented for operands of types 'float' and {b?.GetType()}");
                 }
- 
+
             case double d:
                 switch (b)
                 {
@@ -632,14 +639,17 @@ public static class MathHelper
             default: throw new InvalidOperationException($"Operator '*' not implemented for operands of types {a} and {b?.GetType()}");
         }
     }
-        
-    public static object Divide(object? a, object? b)
+
+    public static object? Divide(object? a, object? b)
     {
         return Divide(a, b, CultureInfo.CurrentCulture);
     }
 
-    public static object Divide(object? a, object? b, CultureInfo cultureInfo)
+    public static object? Divide(object? a, object? b, CultureInfo cultureInfo)
     {
+        if (a == null || b == null)
+            return null;
+
         a = ConvertIfString(a, cultureInfo);
         b = ConvertIfString(b, cultureInfo);
 
@@ -840,17 +850,18 @@ public static class MathHelper
         }
     }
 
-    public static object Modulo(object? a, object? b)
+    public static object? Modulo(object? a, object? b)
     {
         return Modulo(a, b, CultureInfo.CurrentCulture);
     }
 
-    public static object Modulo(object? a, object? b, CultureInfo cultureInfo)
+    public static object? Modulo(object? a, object? b, CultureInfo cultureInfo)
     {
+        if (a == null || b == null)
+            return null;
+
         a = ConvertIfString(a, cultureInfo);
         b = ConvertIfString(b, cultureInfo);
-
-
 
         switch (a)
         {
@@ -1072,7 +1083,7 @@ public static class MathHelper
         {
             return a;
         }
-        
+
         switch (a)
         {
             case byte b1:

--- a/test/NCalc.Tests/EvaluationTests.cs
+++ b/test/NCalc.Tests/EvaluationTests.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using NCalc.Tests.TestData;
 
 namespace NCalc.Tests;

--- a/test/NCalc.Tests/EvaluationTests.cs
+++ b/test/NCalc.Tests/EvaluationTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using NCalc.Tests.TestData;
 
 namespace NCalc.Tests;
@@ -180,5 +181,17 @@ public class EvaluationTests
         surface.Parameters["L"] = 2;
 
         Assert.Equal(6, volume.Evaluate());
+    }
+
+    [Theory]
+    [InlineData("if((5 + null > 0), 1, 2)", 2)]
+    [InlineData("if((5 - null > 0), 1, 2)", 2)]
+    [InlineData("if((5 / null > 0), 1, 2)", 2)]
+    [InlineData("if((5 * null > 0), 1, 2)", 2)]
+    [InlineData("if((5 % null > 0), 1, 2)", 2)]
+    public void ShouldAllowOperatorsWithNulls(string expression, object expected)
+    {
+        var e = new Expression(expression, ExpressionOptions.AllowNullParameter);
+        Assert.Equal(expected, e.Evaluate());
     }
 }


### PR DESCRIPTION
This PR adds support for using null with operators. In this case null value will be returned instead of InvalidOperationException. This is a breaking change