### PR TITLE
Use `IOptions` instead of `IOptionsSnapshot` at `LogicalExpressionMemoryCache`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [Do not convert external function name to lower case when ExpressionOptions.IgnoreCase option is used](https://github.com/ncalc/ncalc/pull/179) by [Andrey Bykiev](https://github.com/Bykiev)
 * [Add support for using null with operators](https://github.com/ncalc/ncalc/pull/184) by [Andrey Bykiev](https://github.com/Bykiev)
 * [Exceptions need to be handled as NCalcEvaluationException instead of ArgumentException and added TypeHelper](https://github.com/ncalc/ncalc/pull/182) by [Gustavo Barros](https://github.com/gumbarros)
+* [Use IOptions instead of IOptionsSnapshot at LogicalExpressionMemoryCache]  by [Gustavo Barros](https://github.com/gumbarros)
 
 # 4.1
 * [Remove excessive check for casing](https://github.com/ncalc/ncalc/pull/149) by [Andrey Bykiev](https://github.com/Bykiev)

--- a/src/Plugins/NCalc.MemoryCache/LogicalExpressionMemoryCache.cs
+++ b/src/Plugins/NCalc.MemoryCache/LogicalExpressionMemoryCache.cs
@@ -7,7 +7,7 @@ namespace NCalc.Cache;
 
 internal sealed class LogicalExpressionMemoryCache(
     IMemoryCache memoryCache,
-    IOptionsSnapshot<LogicalExpressionMemoryCacheOptions> optionsSnapshot) : ILogicalExpressionCache
+    IOptions<LogicalExpressionMemoryCacheOptions> optionsSnapshot) : ILogicalExpressionCache
 {
     public bool TryGetValue(string expression, out LogicalExpression logicalExpression)
     {


### PR DESCRIPTION
This closes #186 