### PR TITLE
Fix culture handling

### DIFF
--- a/src/NCalc/Helpers/MathHelper.cs
+++ b/src/NCalc/Helpers/MathHelper.cs
@@ -1740,8 +1740,8 @@ public static class MathHelper
     {
         return value switch
         {
-            string or char when options.UseDecimals => decimal.Parse(value.ToString()!, options.CultureInfo),
-            string or char => double.Parse(value.ToString()!, options.CultureInfo),
+            string or char when options.UseDecimals => decimal.Parse(Convert.ToString(value, options.CultureInfo)!, options.CultureInfo),
+            string or char => double.Parse(Convert.ToString(value, options.CultureInfo)!, options.CultureInfo),
             bool boolean when options.EnableBooleanCalculation => boolean ? 1 : 0,
             _ => value
         };


### PR DESCRIPTION
By default object.ToString() using CurrentCulture, which cause error with non-invariant culture os.

I've tried to make the test like this on machine with invariant culture by default with no luck

```
var expr = new Expression($"1.1 + [a]", CultureInfo.InvariantCulture);
expr.Parameters["a"] = "2.3";
```