### PR TITLE
Ignore end whitespace in expression

### DIFF
--- a/src/NCalc.Core/Parser/LogicalExpressionParser.cs
+++ b/src/NCalc.Core/Parser/LogicalExpressionParser.cs
@@ -380,7 +380,7 @@ public static class LogicalExpressionParser
                 static (_, _) => throw new InvalidOperationException("Unknown operator sequence.")));
 
         expression.Parser = operatorSequence;
-        var expressionParser = expression.Eof().ElseError(InvalidTokenMessage);
+        var expressionParser = expression.AndSkip(Literals.WhiteSpace()).Eof().ElseError(InvalidTokenMessage);
 
 #if NET6_0_OR_GREATER
         if (System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported)

--- a/test/NCalc.Tests/MathTests.cs
+++ b/test/NCalc.Tests/MathTests.cs
@@ -374,4 +374,16 @@ public class MathsTests
 
         Assert.Equal(expectedValue, res);
     }
+
+    [Theory]
+    [InlineData("11+33 ", 44)]
+    [InlineData(" 11+33", 44)]
+    [InlineData(" 11+33 ", 44)]
+    public void Should_Ignore_Whitespaces(string formula, object expectedValue)
+    {
+        var expr = new Expression(formula, CultureInfo.InvariantCulture);
+        var res = expr.Evaluate();
+
+        Assert.Equal(expectedValue, res);
+    }
 }


### PR DESCRIPTION
This PR fixes throwing an error when expression ends with whitespace (before 4.2.1 the parser didn't throw the error)

Closes #222 