### PR TITLE
Add `MemberNotNullWhen` attribute to `HasErrors`

### DIFF
--- a/src/NCalc.Async/AsyncExpression.cs
+++ b/src/NCalc.Async/AsyncExpression.cs
@@ -5,6 +5,7 @@ using NCalc.Extensions;
 using NCalc.Factories;
 using NCalc.Handlers;
 using NCalc.Visitors;
+using System.Diagnostics.CodeAnalysis;
 
 namespace NCalc;
 
@@ -178,7 +179,8 @@ public class AsyncExpression
     /// Create the LogicalExpression in order to check syntax errors.
     /// If errors are detected, the Error property contains the exception.
     /// </summary>
-    /// <returns>True if the expression syntax is correct, otherwiser False.</returns>
+    /// <returns>True if the expression syntax is correct, otherwise False.</returns>
+    [MemberNotNullWhen(true, nameof(Error))]
     public bool HasErrors()
     {
         try

--- a/src/NCalc.Sync/Expression.cs
+++ b/src/NCalc.Sync/Expression.cs
@@ -4,6 +4,7 @@ using NCalc.Exceptions;
 using NCalc.Factories;
 using NCalc.Handlers;
 using NCalc.Visitors;
+using System.Diagnostics.CodeAnalysis;
 
 namespace NCalc;
 
@@ -154,7 +155,8 @@ public partial class Expression
     /// Create the LogicalExpression in order to check syntax errors.
     /// If errors are detected, the Error property contains the exception.
     /// </summary>
-    /// <returns>True if the expression syntax is correct, otherwiser False.</returns>
+    /// <returns>True if the expression syntax is correct, otherwise False.</returns>
+    [MemberNotNullWhen(true, nameof(Error))]
     public bool HasErrors()
     {
         try


### PR DESCRIPTION
Just a minor improvement that will help alleviate Nullable Reference Type warnings.

Closes #249