### PR TITLE
Overflow protection

### DIFF
--- a/docs/articles/index.md
+++ b/docs/articles/index.md
@@ -15,6 +15,7 @@ For additional information on the technique we used to create this framework ple
 - [Parameters](parameters.md):  How to use parameters expressions.
 - [Handling Errors](handling_errors.md):  How to handle errors.
 - [Case Sensitivity](case_sensitivity.md): Options in how to handle case sensitivity.
+- [Overflow Handling](overflow_protection.md): How to handle overflow with binary arithmetic operations
 - [Async Support](async.md): How and when to use `async`.
 - [Caching](caching.md): How caching works.
 - [Improve performance](lambda_compilation.md): How to use compilation of expressions to CLR lambdas.

--- a/docs/articles/overflow_protection.md
+++ b/docs/articles/overflow_protection.md
@@ -1,0 +1,11 @@
+﻿# Overflow Protection
+
+To handle binary arithmetic operation overflow you should use <xref:NCalc.ExpressionOptions.OverflowProtection>.
+
+```c#
+try
+{
+   var expression = new Expression($"{int.MaxValue} + 1", ExpressionOptions.OverflowProtection);
+}
+catch (OverflowException ex) { }
+```

--- a/src/NCalc.Core/ExpressionEvaluator.cs
+++ b/src/NCalc.Core/ExpressionEvaluator.cs
@@ -41,7 +41,8 @@ public abstract class ExpressionEvaluator
     
     protected MathHelperOptions MathHelperOptions => new(Context.CultureInfo,
         Context.Options.HasFlag(ExpressionOptions.AllowBooleanCalculation),
-        Context.Options.HasFlag(ExpressionOptions.DecimalAsDefault));
+        Context.Options.HasFlag(ExpressionOptions.DecimalAsDefault),
+        Context.Options.HasFlag(ExpressionOptions.OverflowProtection));
 
     protected void ExecuteUnaryExpression(UnaryExpression expression)
     {

--- a/src/NCalc.Core/ExpressionOptions.cs
+++ b/src/NCalc.Core/ExpressionOptions.cs
@@ -57,7 +57,7 @@ public enum ExpressionOptions
     AllowBooleanCalculation = 1 << 9,
 
     /// <summary>
-    /// Check for arithmetic operation overflow
+    /// Check for arithmetic binary operation overflow
     /// </summary>
     OverflowProtection = 1 << 10
 }

--- a/src/NCalc.Core/ExpressionOptions.cs
+++ b/src/NCalc.Core/ExpressionOptions.cs
@@ -55,4 +55,9 @@ public enum ExpressionOptions
     /// Allow calculation with boolean values
     /// </summary>
     AllowBooleanCalculation = 1 << 9,
+
+    /// <summary>
+    /// Check for arithmetic operation overflow
+    /// </summary>
+    OverflowProtection = 1 << 10
 }

--- a/test/NCalc.Tests/MathTests.cs
+++ b/test/NCalc.Tests/MathTests.cs
@@ -390,10 +390,10 @@ public class MathsTests
     }
 
     [Theory]
-    [InlineData(int.MaxValue, '+', 1)]
-    [InlineData(int.MinValue, '-', 1)]
-    [InlineData(int.MaxValue, '*', 1)]
-    [InlineData(int.MinValue, '/', 1)]
+    [InlineData(int.MaxValue, '+', int.MaxValue)]
+    [InlineData(int.MinValue, '-', int.MaxValue)]
+    [InlineData(int.MaxValue, '*', int.MaxValue)]
+    [InlineData(int.MinValue, '/', int.MaxValue)]
     public void Should_Handle_Overflow_Int(int a, char op, int b)
     {
         var e = new Expression($"[a] {op} [b]", ExpressionOptions.OverflowProtection, CultureInfo.InvariantCulture);
@@ -405,9 +405,9 @@ public class MathsTests
 
     [Theory]
     [InlineData(double.MaxValue, '+', double.MaxValue)]
-    [InlineData(double.MinValue, '-', double.MinValue)]
+    [InlineData(double.MinValue, '-', double.MaxValue)]
     [InlineData(double.MaxValue, '*', double.MaxValue)]
-    [InlineData(double.MinValue, '/', double.MinValue)]
+    [InlineData(double.MinValue, '/', double.MaxValue)]
     public void Should_Handle_Overflow_Double(double a, char op, double b)
     {
         var e = new Expression($"[a] {op} [b]", ExpressionOptions.OverflowProtection, CultureInfo.InvariantCulture);
@@ -419,9 +419,9 @@ public class MathsTests
 
     [Theory]
     [InlineData(float.MaxValue, '+', float.MaxValue)]
-    [InlineData(float.MinValue, '-', float.MinValue)]
+    [InlineData(float.MinValue, '-', float.MaxValue)]
     [InlineData(float.MaxValue, '*', float.MaxValue)]
-    [InlineData(float.MinValue, '/', float.MinValue)]
+    [InlineData(float.MinValue, '/', float.MaxValue)]
     public void Should_Handle_Overflow_Float(float a, char op, float b)
     {
         var e = new Expression($"[a] {op} [b]", ExpressionOptions.OverflowProtection, CultureInfo.InvariantCulture);

--- a/test/NCalc.Tests/MathTests.cs
+++ b/test/NCalc.Tests/MathTests.cs
@@ -393,7 +393,6 @@ public class MathsTests
     [InlineData(int.MaxValue, '+', int.MaxValue)]
     [InlineData(int.MinValue, '-', int.MaxValue)]
     [InlineData(int.MaxValue, '*', int.MaxValue)]
-    [InlineData(int.MinValue, '/', int.MaxValue)]
     public void Should_Handle_Overflow_Int(int a, char op, int b)
     {
         var e = new Expression($"[a] {op} [b]", ExpressionOptions.OverflowProtection, CultureInfo.InvariantCulture);
@@ -407,7 +406,7 @@ public class MathsTests
     [InlineData(double.MaxValue, '+', double.MaxValue)]
     [InlineData(double.MinValue, '-', double.MaxValue)]
     [InlineData(double.MaxValue, '*', double.MaxValue)]
-    [InlineData(double.MinValue, '/', double.MaxValue)]
+    [InlineData(double.MinValue, '/', 0.001d)]
     public void Should_Handle_Overflow_Double(double a, char op, double b)
     {
         var e = new Expression($"[a] {op} [b]", ExpressionOptions.OverflowProtection, CultureInfo.InvariantCulture);
@@ -421,7 +420,7 @@ public class MathsTests
     [InlineData(float.MaxValue, '+', float.MaxValue)]
     [InlineData(float.MinValue, '-', float.MaxValue)]
     [InlineData(float.MaxValue, '*', float.MaxValue)]
-    [InlineData(float.MinValue, '/', float.MaxValue)]
+    [InlineData(float.MinValue, '/', 0.001f)]
     public void Should_Handle_Overflow_Float(float a, char op, float b)
     {
         var e = new Expression($"[a] {op} [b]", ExpressionOptions.OverflowProtection, CultureInfo.InvariantCulture);

--- a/test/NCalc.Tests/MathTests.cs
+++ b/test/NCalc.Tests/MathTests.cs
@@ -390,35 +390,44 @@ public class MathsTests
     }
 
     [Theory]
-    [InlineData(int.MaxValue, '+', 1000)]
-    [InlineData(int.MinValue, '-', 1000)]
-    [InlineData(int.MaxValue, '*', 1000)]
-    [InlineData(int.MinValue, '/', 1000)]
+    [InlineData(int.MaxValue, '+', 1)]
+    [InlineData(int.MinValue, '-', 1)]
+    [InlineData(int.MaxValue, '*', 1)]
+    [InlineData(int.MinValue, '/', 1)]
     public void Should_Handle_Overflow_Int(int a, char op, int b)
     {
-        var e = new Expression($"{a.ToString(CultureInfo.InvariantCulture)} {op} {b}", ExpressionOptions.OverflowProtection, CultureInfo.InvariantCulture);
+        var e = new Expression($"[a] {op} [b]", ExpressionOptions.OverflowProtection, CultureInfo.InvariantCulture);
+        e.Parameters["a"] = a;
+        e.Parameters["b"] = b;
+
         Assert.Throws<OverflowException>(() => e.Evaluate());
     }
 
     [Theory]
-    [InlineData(double.MaxValue, '+', 1000)]
-    [InlineData(double.MinValue, '-', 1000)]
-    [InlineData(double.MaxValue, '*', 1000)]
-    [InlineData(double.MinValue, '/', 1000)]
-    public void Should_Handle_Overflow_Double(double a, char op, int b)
+    [InlineData(double.MaxValue, '+', double.MaxValue)]
+    [InlineData(double.MinValue, '-', double.MinValue)]
+    [InlineData(double.MaxValue, '*', double.MaxValue)]
+    [InlineData(double.MinValue, '/', double.MinValue)]
+    public void Should_Handle_Overflow_Double(double a, char op, double b)
     {
-        var e = new Expression($"{a.ToString(CultureInfo.InvariantCulture)} {op} {b}", ExpressionOptions.OverflowProtection, CultureInfo.InvariantCulture);
+        var e = new Expression($"[a] {op} [b]", ExpressionOptions.OverflowProtection, CultureInfo.InvariantCulture);
+        e.Parameters["a"] = a;
+        e.Parameters["b"] = b;
+        
         Assert.Throws<OverflowException>(() => e.Evaluate());
     }
 
     [Theory]
-    [InlineData(float.MaxValue, '+', 1000)]
-    [InlineData(float.MinValue, '-', 1000)]
-    [InlineData(float.MaxValue, '*', 1000)]
-    [InlineData(float.MinValue, '/', 1000)]
-    public void Should_Handle_Overflow_Float(float a, char op, int b)
+    [InlineData(float.MaxValue, '+', float.MaxValue)]
+    [InlineData(float.MinValue, '-', float.MinValue)]
+    [InlineData(float.MaxValue, '*', float.MaxValue)]
+    [InlineData(float.MinValue, '/', float.MinValue)]
+    public void Should_Handle_Overflow_Float(float a, char op, float b)
     {
-        var e = new Expression($"{a.ToString(CultureInfo.InvariantCulture)} {op} {b}", ExpressionOptions.OverflowProtection, CultureInfo.InvariantCulture);
+        var e = new Expression($"[a] {op} [b]", ExpressionOptions.OverflowProtection, CultureInfo.InvariantCulture);
+        e.Parameters["a"] = a;
+        e.Parameters["b"] = b;
+
         Assert.Throws<OverflowException>(() => e.Evaluate());
     }
 }

--- a/test/NCalc.Tests/MathTests.cs
+++ b/test/NCalc.Tests/MathTests.cs
@@ -388,4 +388,37 @@ public class MathsTests
 
         Assert.Equal(expectedValue, res);
     }
+
+    [Theory]
+    [InlineData(int.MaxValue, '+', 1000)]
+    [InlineData(int.MinValue, '-', 1000)]
+    [InlineData(int.MaxValue, '*', 1000)]
+    [InlineData(int.MinValue, '/', 1000)]
+    public void Should_Handle_Overflow_Int(int a, char op, int b)
+    {
+        var e = new Expression($"{a.ToString(CultureInfo.InvariantCulture)} {op} {b}", ExpressionOptions.OverflowProtection, CultureInfo.InvariantCulture);
+        Assert.Throws<OverflowException>(() => e.Evaluate());
+    }
+
+    [Theory]
+    [InlineData(double.MaxValue, '+', 1000)]
+    [InlineData(double.MinValue, '-', 1000)]
+    [InlineData(double.MaxValue, '*', 1000)]
+    [InlineData(double.MinValue, '/', 1000)]
+    public void Should_Handle_Overflow_Double(double a, char op, int b)
+    {
+        var e = new Expression($"{a.ToString(CultureInfo.InvariantCulture)} {op} {b}", ExpressionOptions.OverflowProtection, CultureInfo.InvariantCulture);
+        Assert.Throws<OverflowException>(() => e.Evaluate());
+    }
+
+    [Theory]
+    [InlineData(float.MaxValue, '+', 1000)]
+    [InlineData(float.MinValue, '-', 1000)]
+    [InlineData(float.MaxValue, '*', 1000)]
+    [InlineData(float.MinValue, '/', 1000)]
+    public void Should_Handle_Overflow_Float(float a, char op, int b)
+    {
+        var e = new Expression($"{a.ToString(CultureInfo.InvariantCulture)} {op} {b}", ExpressionOptions.OverflowProtection, CultureInfo.InvariantCulture);
+        Assert.Throws<OverflowException>(() => e.Evaluate());
+    }
 }


### PR DESCRIPTION
This PR adds support for handling overflow with binary arithmetic operators (+,-,*,/). To handle overflow `ExpressionOptions.OverflowProtection` should be specified.

Closes #206