### PR TITLE
Small performance improvement for `BinaryExpression`

### DIFF
--- a/src/NCalc.Async/Visitors/AsyncEvaluationVisitor.cs
+++ b/src/NCalc.Async/Visitors/AsyncEvaluationVisitor.cs
@@ -1,5 +1,6 @@
 ﻿using ExtendedNumerics;
 using System.Numerics;
+using System.Threading;
 using NCalc.Domain;
 using NCalc.Exceptions;
 using NCalc.Handlers;
@@ -33,8 +34,8 @@ public class AsyncEvaluationVisitor(AsyncExpressionContext context) : ILogicalEx
 
     public async Task<object?> Visit(BinaryExpression expression)
     {
-        var leftValue = new Lazy<ValueTask<object?>>(() => EvaluateAsync(expression.LeftExpression));
-        var rightValue = new Lazy<ValueTask<object?>>(() => EvaluateAsync(expression.RightExpression));
+        var leftValue = new Lazy<ValueTask<object?>>(() => EvaluateAsync(expression.LeftExpression), LazyThreadSafetyMode.None);
+        var rightValue = new Lazy<ValueTask<object?>>(() => EvaluateAsync(expression.RightExpression), LazyThreadSafetyMode.None);
 
         switch (expression.Type)
         {

--- a/src/NCalc.Sync/Visitors/EvaluationVisitor.cs
+++ b/src/NCalc.Sync/Visitors/EvaluationVisitor.cs
@@ -31,8 +31,8 @@ public class EvaluationVisitor(ExpressionContext context) : ILogicalExpressionVi
 
     public object? Visit(BinaryExpression expression)
     {
-        var leftValue = new Lazy<object?>(() => Evaluate(expression.LeftExpression));
-        var rightValue = new Lazy<object?>(() => Evaluate(expression.RightExpression));
+        var leftValue = new Lazy<object?>(() => Evaluate(expression.LeftExpression), LazyThreadSafetyMode.None);
+        var rightValue = new Lazy<object?>(() => Evaluate(expression.RightExpression), LazyThreadSafetyMode.None);
 
         switch (expression.Type)
         {


### PR DESCRIPTION
| Method           | Mean     | Error    | StdDev   | Rank | Gen0   | Allocated |
|----------------- |---------:|---------:|---------:|-----:|-------:|----------:|
| UnsafeExpression | 14.72 us | 0.042 us | 0.039 us |    1 | 0.3967 |   3.24 KB |
| SafeExpression   | 15.12 us | 0.118 us | 0.104 us |    2 | 0.4272 |   3.55 KB |

I think we don't need thread safety as this is a variable and not a property right?