### PR TITLE
Move event handlers to `ExpressionContext`

### DIFF
--- a/src/NCalc.Async/AsyncExpression.cs
+++ b/src/NCalc.Async/AsyncExpression.cs
@@ -71,8 +71,8 @@ public class AsyncExpression
     /// </summary>
     public event AsyncEvaluateFunctionHandler EvaluateFunctionAsync
     {
-        add => EvaluationService.EvaluateFunctionAsync += value;
-        remove => EvaluationService.EvaluateFunctionAsync -= value;
+        add => Context.AsyncEvaluateFunctionHandler += value;
+        remove => Context.AsyncEvaluateFunctionHandler -= value;
     }
     
     /// <summary>
@@ -80,8 +80,8 @@ public class AsyncExpression
     /// </summary>
     public event AsyncEvaluateParameterHandler EvaluateParameterAsync
     {
-        add => EvaluationService.EvaluateParameterAsync += value;
-        remove => EvaluationService.EvaluateParameterAsync -= value;
+        add => Context.AsyncEvaluateParameterHandler += value;
+        remove => Context.AsyncEvaluateParameterHandler -= value;
     }
     
     /// <summary>

--- a/src/NCalc.Async/AsyncExpressionContext.cs
+++ b/src/NCalc.Async/AsyncExpressionContext.cs
@@ -1,3 +1,5 @@
+using NCalc.Handlers;
+
 namespace NCalc;
 
 public record AsyncExpressionContext : ExpressionContextBase
@@ -8,6 +10,10 @@ public record AsyncExpressionContext : ExpressionContextBase
     public IDictionary<string, AsyncExpressionFunction> Functions { get; set; } =
         new Dictionary<string, AsyncExpressionFunction>();
 
+    
+    public AsyncEvaluateParameterHandler? AsyncEvaluateParameterHandler { get; set; }
+    public AsyncEvaluateFunctionHandler? AsyncEvaluateFunctionHandler { get; set; }
+    
     public AsyncExpressionContext()
     {
     }

--- a/src/NCalc.Async/Services/AsyncEvaluationService.cs
+++ b/src/NCalc.Async/Services/AsyncEvaluationService.cs
@@ -1,5 +1,4 @@
 using NCalc.Domain;
-using NCalc.Handlers;
 using NCalc.Visitors;
 
 namespace NCalc.Services;
@@ -7,14 +6,10 @@ namespace NCalc.Services;
 /// <inheritdoc cref="IAsyncEvaluationService"/>
 public class AsyncEvaluationService : IAsyncEvaluationService
 {
-    public event AsyncEvaluateFunctionHandler? EvaluateFunctionAsync;
-    public event AsyncEvaluateParameterHandler? EvaluateParameterAsync;
-
+    
     public Task<object?> EvaluateAsync(LogicalExpression expression, AsyncExpressionContext context)
     {
         var visitor = new AsyncEvaluationVisitor(context);
-        visitor.EvaluateFunctionAsync += EvaluateFunctionAsync;
-        visitor.EvaluateParameterAsync += EvaluateParameterAsync;
         return expression.Accept(visitor);
     }
 }

--- a/src/NCalc.Async/Services/IAsyncEvaluationService.cs
+++ b/src/NCalc.Async/Services/IAsyncEvaluationService.cs
@@ -8,8 +8,5 @@ namespace NCalc.Services;
 /// </summary>
 public interface IAsyncEvaluationService
 {
-    public event AsyncEvaluateFunctionHandler? EvaluateFunctionAsync;
-    public event AsyncEvaluateParameterHandler? EvaluateParameterAsync;
-
     Task<object?> EvaluateAsync(LogicalExpression expression, AsyncExpressionContext context);
 }

--- a/src/NCalc.Async/Visitors/AsyncEvaluationVisitor.cs
+++ b/src/NCalc.Async/Visitors/AsyncEvaluationVisitor.cs
@@ -16,9 +16,6 @@ namespace NCalc.Visitors;
 /// <param name="context">Contextual parameters of the <see cref="LogicalExpression"/>, like custom functions and parameters.</param>
 public class AsyncEvaluationVisitor(AsyncExpressionContext context) : ILogicalExpressionVisitor<Task<object?>>
 {
-    public event AsyncEvaluateFunctionHandler? EvaluateFunctionAsync;
-    public event AsyncEvaluateParameterHandler? EvaluateParameterAsync;
-
     public async Task<object?> Visit(TernaryExpression expression)
     {
         // Evaluates the left expression and saves the value
@@ -166,8 +163,6 @@ public class AsyncEvaluationVisitor(AsyncExpressionContext context) : ILogicalEx
         for (var i = 0; i < argsCount; i++)
         {
             args[i] = new AsyncExpression(function.Expressions[i], context);
-            args[i].EvaluateParameterAsync += EvaluateParameterAsync;
-            args[i].EvaluateFunctionAsync += EvaluateFunctionAsync;
         }
 
         var functionName = function.Identifier.Name;
@@ -212,8 +207,8 @@ public class AsyncEvaluationVisitor(AsyncExpressionContext context) : ILogicalEx
                 foreach (var p in context.DynamicParameters)
                     expression.DynamicParameters[p.Key] = p.Value;
 
-                expression.EvaluateFunctionAsync += EvaluateFunctionAsync;
-                expression.EvaluateParameterAsync += EvaluateParameterAsync;
+                expression.EvaluateFunctionAsync += context.AsyncEvaluateFunctionHandler;
+                expression.EvaluateParameterAsync += context.AsyncEvaluateParameterHandler;
 
                 return await expression.EvaluateAsync();
             }
@@ -238,12 +233,12 @@ public class AsyncEvaluationVisitor(AsyncExpressionContext context) : ILogicalEx
 
     protected ValueTask OnEvaluateFunctionAsync(string name, AsyncFunctionArgs args)
     {
-        return EvaluateFunctionAsync?.Invoke(name, args) ?? default;
+        return context.AsyncEvaluateFunctionHandler?.Invoke(name, args) ?? default;
     }
 
     protected ValueTask OnEvaluateParameterAsync(string name, AsyncParameterArgs args)
     {
-        return EvaluateParameterAsync?.Invoke(name, args) ?? default;
+        return context.AsyncEvaluateParameterHandler?.Invoke(name, args) ?? default;
     }
 
     private async ValueTask<object?> EvaluateAsync(LogicalExpression expression)

--- a/src/NCalc.Sync/Expression.cs
+++ b/src/NCalc.Sync/Expression.cs
@@ -28,8 +28,8 @@ public partial class Expression
     /// </summary>
     public event EvaluateFunctionHandler EvaluateFunction
     {
-        add => EvaluationService.EvaluateFunction += value;
-        remove => EvaluationService.EvaluateFunction -= value;
+        add => Context.EvaluateFunctionHandler += value;
+        remove => Context.EvaluateFunctionHandler -= value;
     }
     
     /// <summary>
@@ -37,8 +37,8 @@ public partial class Expression
     /// </summary>
     public event EvaluateParameterHandler EvaluateParameter
     {
-        add => EvaluationService.EvaluateParameter += value;
-        remove => EvaluationService.EvaluateParameter -= value;
+        add => Context.EvaluateParameterHandler += value;
+        remove => Context.EvaluateParameterHandler -= value;
     }
     
     /// <summary>

--- a/src/NCalc.Sync/ExpressionContext.cs
+++ b/src/NCalc.Sync/ExpressionContext.cs
@@ -1,3 +1,5 @@
+using NCalc.Handlers;
+
 namespace NCalc;
 
 public record ExpressionContext : ExpressionContextBase
@@ -6,6 +8,9 @@ public record ExpressionContext : ExpressionContextBase
 
     public IDictionary<string, ExpressionFunction> Functions { get; set; } = new Dictionary<string, ExpressionFunction>();
 
+    public EvaluateParameterHandler? EvaluateParameterHandler { get; set; }
+    public EvaluateFunctionHandler? EvaluateFunctionHandler { get; set; }
+    
     public ExpressionContext()
     {
     }

--- a/src/NCalc.Sync/Services/EvaluationService.cs
+++ b/src/NCalc.Sync/Services/EvaluationService.cs
@@ -7,15 +7,9 @@ namespace NCalc.Services;
 /// <inheritdoc cref="IEvaluationService"/>
 public class EvaluationService : IEvaluationService
 {
-    public event EvaluateFunctionHandler? EvaluateFunction;
-    public event EvaluateParameterHandler? EvaluateParameter;
     public object? Evaluate(LogicalExpression expression, ExpressionContext context)
     {
         var visitor = new EvaluationVisitor(context);
-        
-        visitor.EvaluateFunction += EvaluateFunction;
-        visitor.EvaluateParameter += EvaluateParameter;
-        
         return expression.Accept(visitor);
     }
 }

--- a/src/NCalc.Sync/Services/IEvaluationService.cs
+++ b/src/NCalc.Sync/Services/IEvaluationService.cs
@@ -1,5 +1,4 @@
 using NCalc.Domain;
-using NCalc.Handlers;
 
 namespace NCalc.Services;
 
@@ -8,7 +7,5 @@ namespace NCalc.Services;
 /// </summary>
 public interface IEvaluationService
 {
-    public event EvaluateFunctionHandler? EvaluateFunction;
-    public event EvaluateParameterHandler? EvaluateParameter;
     object? Evaluate(LogicalExpression expression, ExpressionContext context);
 }

--- a/test/NCalc.Benchmarks/Program.cs
+++ b/test/NCalc.Benchmarks/Program.cs
@@ -2,4 +2,5 @@
 using NCalc.Benchmarks;
 
 BenchmarkRunner.Run<LogicalExpressionFactoryBenchmark>(null, args);
+BenchmarkRunner.Run<SimpleEvaluationBenchmark>(null, args);
 BenchmarkRunner.Run<EvaluateVsLambdaBenchmark>(null, args);

--- a/test/NCalc.Benchmarks/SimpleEvaluationBenchmark.cs
+++ b/test/NCalc.Benchmarks/SimpleEvaluationBenchmark.cs
@@ -1,0 +1,42 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Order;
+using NCalc.Factories;
+using NCalc.Handlers;
+
+namespace NCalc.Benchmarks;
+
+[RankColumn]
+[CategoriesColumn]
+[MemoryDiagnoser]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+public class SimpleEvaluationBenchmark
+{
+    private Expression Expression { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var logicalExpression = LogicalExpressionFactory.Create("pi == 3.14 || 'Chers' == name");
+        var expression = new Expression(logicalExpression)
+        {
+            Parameters =
+            {
+                ["name"] = "Chers"
+            }
+        };
+
+        expression.EvaluateParameter += delegate(string name, ParameterArgs args)
+        {
+            if (name == "pi")
+                args.Result = 3.14;
+        };
+
+        Expression = expression;
+    }
+    
+    [Benchmark]
+    public object SimpleEvaluation()
+    {
+        return Expression.Evaluate();
+    }
+}


### PR DESCRIPTION
Trying to solve #277, did not yield any significant performance changes, but the public API looks cleaner.

Before:
| Method           | Mean     | Error   | StdDev  | Rank | Gen0   | Allocated |
|----------------- |---------:|--------:|--------:|-----:|-------:|----------:|
| SimpleEvaluation | 257.0 ns | 2.32 ns | 2.05 ns |    1 | 0.0820 |     688 B |


After:
| Method           | Mean     | Error   | StdDev  | Rank | Gen0   | Allocated |
|----------------- |---------:|--------:|--------:|-----:|-------:|----------:|
| SimpleEvaluation | 246.3 ns | 4.65 ns | 7.38 ns |    1 | 0.0801 |     672 B |
