### PR TITLE
Added `EvaluationHelper` and `in` operator should respect string comparer

### DIFF
--- a/src/NCalc.Async/AsyncExpression.cs
+++ b/src/NCalc.Async/AsyncExpression.cs
@@ -11,7 +11,7 @@ using NCalc.Services;
 namespace NCalc;
 
 /// <summary>
-/// This class represents a mathematical or logical expression that can be evaluated.
+/// This class represents a mathematical or logical expression that can be asynchronous evaluated.
 /// It supports caching, custom parameter and function evaluation, and options for handling null parameters and iterating over parameter collections.
 /// The class manages the parsing, validation, and evaluation of expressions, and provides mechanisms for error detection and reporting.
 /// </summary>
@@ -218,10 +218,12 @@ public class AsyncExpression
         }
     }
     
+
     /// <summary>
-    /// Asynchronous evaluate the expression and return the Task.
+    /// Asynchronously evaluates the logical expression.
     /// </summary>
     /// <returns>The result of the evaluation.</returns>
+    /// <exception cref="NCalcException">Thrown when there is an error in the expression.</exception>
     public async Task<object?> EvaluateAsync()
     {
         LogicalExpression ??= GetLogicalExpression();

--- a/src/NCalc.Async/Visitors/AsyncEvaluationVisitor.cs
+++ b/src/NCalc.Async/Visitors/AsyncEvaluationVisitor.cs
@@ -230,7 +230,7 @@ public class AsyncEvaluationVisitor(AsyncExpressionContext context) : ILogicalEx
             result.Add(await EvaluateAsync(value));
         }
 
-        return result.ToArray();
+        return result;
     }
 
     protected int CompareUsingMostPreciseType(object? a, object? b)

--- a/src/NCalc.Core/Helpers/EvaluationHelper.cs
+++ b/src/NCalc.Core/Helpers/EvaluationHelper.cs
@@ -1,0 +1,82 @@
+using NCalc.Domain;
+using NCalc.Exceptions;
+
+namespace NCalc.Helpers;
+
+/// <summary>
+/// Provides helper methods for evaluating expressions.
+/// </summary>
+public static class EvaluationHelper
+{
+    /// <summary>
+    /// Adds two values, with special handling for string concatenation based on the context options.
+    /// </summary>
+    /// <param name="leftValue">The left operand.</param>
+    /// <param name="rightValue">The right operand.</param>
+    /// <param name="context">The evaluation context.</param>
+    /// <returns>The result of the addition or string concatenation.</returns>
+    public static object? Plus(object? leftValue, object? rightValue, ExpressionContextBase context)
+    {
+        if (context.Options.HasFlag(ExpressionOptions.StringConcat))
+            return string.Concat(leftValue, rightValue);
+
+        try
+        {
+            return MathHelper.Add(leftValue, rightValue, context);
+        }
+        catch (FormatException) when (leftValue is string && rightValue is string)
+        {
+            return string.Concat(leftValue, rightValue);
+        }
+    }
+    
+    /// <summary>
+    /// Determines if the left value is contained within the right value, which must be either an enumerable or a string.
+    /// </summary>
+    /// <param name="rightValue">The right operand.</param>
+    /// <param name="leftValue">The left operand.</param>
+    /// <param name="context">The evaluation context.</param>
+    /// <returns>True if the left value is contained within the right value, otherwise false.</returns>
+    /// <exception cref="NCalcEvaluationException">Thrown when the right value is not an enumerable or a string.</exception>
+    public static bool In(object? rightValue, object? leftValue, ExpressionContextBase context)
+    {
+        switch (rightValue)
+        {
+            case IEnumerable<object?> rightValueEnumerable:
+            {
+                var rightArray = rightValueEnumerable as object[] ?? rightValueEnumerable.ToArray();
+
+                if (rightArray.All(v => v is string))
+                    return rightArray.OfType<string>().Contains(leftValue?.ToString() ?? string.Empty,
+                        TypeHelper.GetStringComparer(context));
+
+                return rightArray.Contains(leftValue);
+            }
+            case string rightValueString:
+                return rightValueString.Contains(leftValue?.ToString() ?? string.Empty);
+            default:
+                throw new NCalcEvaluationException(
+                    "'in' operator right value must implement IEnumerable or be a string.");
+        }
+    }
+    
+    /// <summary>
+    /// Evaluates a unary expression.
+    /// </summary>
+    /// <param name="expression">The unary expression to evaluate.</param>
+    /// <param name="result">The result of evaluating the operand of the unary expression.</param>
+    /// <param name="context">The evaluation context.</param>
+    /// <returns>The result of the unary operation.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the unary expression type is unknown.</exception>
+    public static object? Unary(UnaryExpression expression, object? result, ExpressionContextBase context)
+    {
+        return expression.Type switch
+        {
+            UnaryExpressionType.Not => !Convert.ToBoolean(result, context.CultureInfo),
+            UnaryExpressionType.Negate => MathHelper.Subtract(0, result, context),
+            UnaryExpressionType.BitwiseNot => ~Convert.ToUInt64(result, context.CultureInfo),
+            UnaryExpressionType.Positive => result,
+            _ => throw new InvalidOperationException("Unknown UnaryExpressionType")
+        };
+    }
+}

--- a/src/NCalc.Core/Helpers/ParametersHelper.cs
+++ b/src/NCalc.Core/Helpers/ParametersHelper.cs
@@ -2,8 +2,18 @@ using NCalc.Exceptions;
 
 namespace NCalc.Helpers;
 
+/// <summary>
+/// Provides helper methods for handling parameters.
+/// </summary>
 public static class ParametersHelper
 {
+    /// <summary>
+    /// Gets enumerators for the IEnumerable parameters and checks that they all have the same number of items.
+    /// </summary>
+    /// <param name="parameters">The dictionary of parameters.</param>
+    /// <param name="size">The size of the enumerable, if any. Set to null if there are no IEnumerable parameters.</param>
+    /// <returns>A dictionary of parameter names and their corresponding enumerators.</returns>
+    /// <exception cref="NCalcException">Thrown when the IEnumerable parameters do not have the same number of items.</exception>
     public static Dictionary<string, IEnumerator> GetEnumerators(IDictionary<string,object?> parameters, out int? size)
     {
         var parameterEnumerators = new Dictionary<string, IEnumerator>();

--- a/src/NCalc.Core/Helpers/TypeHelper.cs
+++ b/src/NCalc.Core/Helpers/TypeHelper.cs
@@ -113,19 +113,26 @@ public static class TypeHelper
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsReal(object? value) => value is decimal or double or float;
 
+    public static StringComparer GetStringComparer(ComparisonOptions options)
+    {
+        return options.IsOrdinal switch
+        {
+            true when options.IsCaseInsensitive => StringComparer.OrdinalIgnoreCase,
+            true => StringComparer.Ordinal,
+            false when options.IsCaseInsensitive => StringComparer.CurrentCultureIgnoreCase,
+            _ => StringComparer.CurrentCulture
+        };
+    }
+
     public static int CompareUsingMostPreciseType(object? a, object? b, ComparisonOptions options)
     {
         var mpt = GetMostPreciseType(a?.GetType(), b?.GetType());
 
         var aValue = a != null ? Convert.ChangeType(a, mpt, options.CultureInfo) : null;
         var bValue = b != null ? Convert.ChangeType(b, mpt, options.CultureInfo) : null;
+
+        var comparer = GetStringComparer(options);
         
-        return options.IsOrdinal switch
-        {
-            true when options.IsCaseInsensitive => StringComparer.OrdinalIgnoreCase.Compare(aValue, bValue),
-            true => StringComparer.Ordinal.Compare(aValue, bValue),
-            false when options.IsCaseInsensitive => CaseInsensitiveComparer.Default.Compare(aValue, bValue),
-            _ => Comparer.Default.Compare(aValue, bValue)
-        };
+        return comparer.Compare(aValue, bValue);
     }
 }

--- a/src/NCalc.Core/Helpers/TypeHelper.cs
+++ b/src/NCalc.Core/Helpers/TypeHelper.cs
@@ -75,7 +75,7 @@ public static class TypeHelper
         }.ToFrozenDictionary();
 
     /// <summary>
-    /// Gets the the most precise type.
+    /// Gets the most precise type.
     /// </summary>
     /// <param name="a">Type a.</param>
     /// <param name="b">Type b.</param>

--- a/src/NCalc.Sync/Expression.cs
+++ b/src/NCalc.Sync/Expression.cs
@@ -187,9 +187,10 @@ public partial class Expression
     }
 
     /// <summary>
-    /// Evaluate the expression and return the result.
+    /// Evaluates the logical expression.
     /// </summary>
     /// <returns>The result of the evaluation.</returns>
+    /// <exception cref="NCalcException">Thrown when there is an error in the expression.</exception>
     public object? Evaluate()
     {
         LogicalExpression ??= GetLogicalExpression();

--- a/src/NCalc.Sync/Visitors/EvaluationVisitor.cs
+++ b/src/NCalc.Sync/Visitors/EvaluationVisitor.cs
@@ -4,6 +4,7 @@ using NCalc.Exceptions;
 using NCalc.Handlers;
 using NCalc.Helpers;
 using System.Numerics;
+using static NCalc.Helpers.TypeHelper;
 
 namespace NCalc.Visitors;
 
@@ -35,14 +36,14 @@ public class EvaluationVisitor(ExpressionContext context) : ILogicalExpressionVi
         {
             case BinaryExpressionType.And:
                 return Convert.ToBoolean(left.Value, context.CultureInfo) &&
-                         Convert.ToBoolean(right.Value, context.CultureInfo);
+                       Convert.ToBoolean(right.Value, context.CultureInfo);
 
             case BinaryExpressionType.Or:
                 return Convert.ToBoolean(left.Value, context.CultureInfo) ||
-                         Convert.ToBoolean(right.Value, context.CultureInfo);
+                       Convert.ToBoolean(right.Value, context.CultureInfo);
 
             case BinaryExpressionType.Div:
-                return TypeHelper.IsReal(left.Value) || TypeHelper.IsReal(right.Value)
+                return IsReal(left.Value) || IsReal(right.Value)
                     ? MathHelper.Divide(left.Value, right.Value, context)
                     : MathHelper.Divide(Convert.ToDouble(left.Value, context.CultureInfo), right.Value,
                         context);
@@ -72,22 +73,12 @@ public class EvaluationVisitor(ExpressionContext context) : ILogicalExpressionVi
                 return CompareUsingMostPreciseType(left.Value, right.Value) != 0;
 
             case BinaryExpressionType.Plus:
-                {
-                    var leftValue = left.Value;
-                    var rightValue = right.Value;
+            {
+                var leftValue = left.Value;
+                var rightValue = right.Value;
 
-                    if (context.Options.HasFlag(ExpressionOptions.StringConcat))
-                        return string.Concat(leftValue, rightValue);
-
-                    try
-                    {
-                        return MathHelper.Add(leftValue, rightValue, context);
-                    }
-                    catch (FormatException) when (leftValue is string && rightValue is string)
-                    {
-                        return string.Concat(leftValue, rightValue);
-                    }
-                }
+                return EvaluationHelper.Plus(leftValue, rightValue, context);
+            }
 
             case BinaryExpressionType.Times:
                 return MathHelper.Multiply(left.Value, right.Value, context);
@@ -95,58 +86,50 @@ public class EvaluationVisitor(ExpressionContext context) : ILogicalExpressionVi
 
             case BinaryExpressionType.BitwiseAnd:
                 return Convert.ToUInt64(left.Value, context.CultureInfo) &
-                         Convert.ToUInt64(right.Value, context.CultureInfo);
+                       Convert.ToUInt64(right.Value, context.CultureInfo);
 
 
             case BinaryExpressionType.BitwiseOr:
                 return Convert.ToUInt64(left.Value, context.CultureInfo) |
-                         Convert.ToUInt64(right.Value, context.CultureInfo);
+                       Convert.ToUInt64(right.Value, context.CultureInfo);
 
 
             case BinaryExpressionType.BitwiseXOr:
                 return Convert.ToUInt64(left.Value, context.CultureInfo) ^
-                         Convert.ToUInt64(right.Value, context.CultureInfo);
+                       Convert.ToUInt64(right.Value, context.CultureInfo);
 
 
             case BinaryExpressionType.LeftShift:
                 return Convert.ToUInt64(left.Value, context.CultureInfo) <<
-                         Convert.ToInt32(right.Value, context.CultureInfo);
+                       Convert.ToInt32(right.Value, context.CultureInfo);
 
 
             case BinaryExpressionType.RightShift:
                 return Convert.ToUInt64(left.Value, context.CultureInfo) >>
-                         Convert.ToInt32(right.Value, context.CultureInfo);
+                       Convert.ToInt32(right.Value, context.CultureInfo);
 
             case BinaryExpressionType.Exponentiation:
-                {
-                    if (!context.Options.HasFlag(ExpressionOptions.DecimalAsDefault))
-                        return Math.Pow(Convert.ToDouble(left.Value, context.CultureInfo),
-                            Convert.ToDouble(right.Value, context.CultureInfo));
-                    BigDecimal @base = new BigDecimal(Convert.ToDecimal(left.Value));
-                    BigInteger exponent = new BigInteger(Convert.ToDecimal(right.Value));
+            {
+                if (!context.Options.HasFlag(ExpressionOptions.DecimalAsDefault))
+                    return Math.Pow(Convert.ToDouble(left.Value, context.CultureInfo),
+                        Convert.ToDouble(right.Value, context.CultureInfo));
+                BigDecimal @base = new BigDecimal(Convert.ToDecimal(left.Value));
+                BigInteger exponent = new BigInteger(Convert.ToDecimal(right.Value));
 
-                    return (decimal)BigDecimal.Pow(@base, exponent);
-                }
+                return (decimal)BigDecimal.Pow(@base, exponent);
+            }
 
             case BinaryExpressionType.In:
             {
-                return right.Value switch
-                {
-                    IEnumerable<object> rightValueEnumerable => rightValueEnumerable.Contains(left.Value),
-                    string rightValueString => rightValueString.Contains(left.Value?.ToString() ?? string.Empty),
-                    _ => throw new NCalcEvaluationException(
-                        "'in' operator right value must implement IEnumerable or be a string.")
-                };
+                var rightValue = right.Value;
+                var leftValue = left.Value;
+                return EvaluationHelper.In(rightValue, leftValue, context);
             }
             case BinaryExpressionType.NotIn:
             {
-                return right.Value switch
-                {
-                    IEnumerable<object> rightValueEnumerable => !rightValueEnumerable.Contains(left.Value),
-                    string rightValueString => !rightValueString.Contains(left.Value?.ToString() ?? string.Empty),
-                    _ => throw new NCalcEvaluationException(
-                        "'not in' operator right value must implement IEnumerable or be a string.")
-                };
+                var rightValue = right.Value;
+                var leftValue = left.Value;
+                return !EvaluationHelper.In(rightValue, leftValue, context);
             }
         }
 
@@ -158,14 +141,7 @@ public class EvaluationVisitor(ExpressionContext context) : ILogicalExpressionVi
         // Recursively evaluates the underlying expression
         var result = expression.Expression.Accept(this);
 
-        return expression.Type switch
-        {
-            UnaryExpressionType.Not => !Convert.ToBoolean(result, context.CultureInfo),
-            UnaryExpressionType.Negate => MathHelper.Subtract(0, result, context),
-            UnaryExpressionType.BitwiseNot => ~Convert.ToUInt64(result, context.CultureInfo),
-            UnaryExpressionType.Positive => result,
-            _ => throw new InvalidOperationException("Unknown UnaryExpressionType")
-        };
+        return EvaluationHelper.Unary(expression, result, context);
     }
 
     public object? Visit(ValueExpression expression) => expression.Value;
@@ -189,9 +165,7 @@ public class EvaluationVisitor(ExpressionContext context) : ILogicalExpressionVi
         OnEvaluateFunction(functionName, functionArgs);
 
         if (functionArgs.HasResult)
-        {
             return functionArgs.Result;
-        }
 
         if (context.Functions.TryGetValue(functionName, out var expressionFunction))
         {
@@ -227,7 +201,7 @@ public class EvaluationVisitor(ExpressionContext context) : ILogicalExpressionVi
 
                 expression.EvaluateFunction += context.EvaluateFunctionHandler;
                 expression.EvaluateParameter += context.EvaluateParameterHandler;
-                
+
                 return expression.Evaluate();
             }
 
@@ -247,21 +221,21 @@ public class EvaluationVisitor(ExpressionContext context) : ILogicalExpressionVi
         List<object?> result = [];
 
         foreach (var value in list)
-        {
             result.Add(Evaluate(value));
-        }
 
-        return result.ToArray();
+        return result;
     }
 
     protected int CompareUsingMostPreciseType(object? a, object? b)
     {
         return TypeHelper.CompareUsingMostPreciseType(a, b, context);
     }
+
     protected void OnEvaluateFunction(string name, FunctionArgs args)
     {
         context.EvaluateFunctionHandler?.Invoke(name, args);
     }
+
     protected void OnEvaluateParameter(string name, ParameterArgs args)
     {
         context.EvaluateParameterHandler?.Invoke(name, args);

--- a/test/NCalc.Tests/EvaluationTests.cs
+++ b/test/NCalc.Tests/EvaluationTests.cs
@@ -237,4 +237,12 @@ public class EvaluationTests
         context.StaticParameters["PageState"] = "Import";
         Assert.Equal(true, new Expression("{PageState} not in  ('Insert','Update')", context).Evaluate());
     }
+    
+    [Fact]
+    public void InOperatorShouldRespectStringComparer()
+    {
+        ExpressionContext context = ExpressionOptions.CaseInsensitiveStringComparer;
+        context.StaticParameters["PageState"] = "Insert";
+        Assert.Equal(true, new Expression("{PageState} in ('INSERT','UPDATE')", context).Evaluate());
+    }
 }


### PR DESCRIPTION
The string comparer part is very important for me. `EvaluationHelper` reduces code duplication of sync and async.