### PR TITLE
Breaking Change: Use `ValueTask` instead of `Task` at `NCalc.Async`

### DIFF
--- a/src/NCalc.Async/AsyncExpression.cs
+++ b/src/NCalc.Async/AsyncExpression.cs
@@ -113,7 +113,7 @@ public class AsyncExpression : ExpressionBase<AsyncExpressionContext>
     /// </summary>
     /// <returns>The result of the evaluation.</returns>
     /// <exception cref="NCalcException">Thrown when there is an error in the expression.</exception>
-    public Task<object?> EvaluateAsync()
+    public ValueTask<object?> EvaluateAsync()
     {
         LogicalExpression ??= GetLogicalExpression();
 
@@ -130,7 +130,7 @@ public class AsyncExpression : ExpressionBase<AsyncExpressionContext>
         return EvaluationService.EvaluateAsync(LogicalExpression!, Context);
     }
 
-    private async Task<object?> IterateParametersAsync()
+    private async ValueTask<object?> IterateParametersAsync()
     {
         var parameterEnumerators = ParametersHelper.GetEnumerators(Parameters, out var size);
 

--- a/src/NCalc.Async/Handlers/AsyncFunctionArgs.cs
+++ b/src/NCalc.Async/Handlers/AsyncFunctionArgs.cs
@@ -20,7 +20,7 @@ public class AsyncFunctionArgs(Guid id, AsyncExpression[] parameters) : EventArg
 
     public bool HasResult { get; private set; }
 
-    public async Task<object?[]> EvaluateParametersAsync()
+    public async ValueTask<object?[]> EvaluateParametersAsync()
     {
         var values = new object?[Parameters.Length];
         for (var i = 0; i < values.Length; i++)

--- a/src/NCalc.Async/Helpers/AsyncBuiltInFunctionHelper.cs
+++ b/src/NCalc.Async/Helpers/AsyncBuiltInFunctionHelper.cs
@@ -4,7 +4,7 @@ namespace NCalc.Helpers;
 
 public static class AsyncBuiltInFunctionHelper
 {
-    public static async Task<object?> EvaluateAsync(string functionName, AsyncExpression[] arguments, AsyncExpressionContext context)
+    public static async ValueTask<object?> EvaluateAsync(string functionName, AsyncExpression[] arguments, AsyncExpressionContext context)
     {
         var caseInsensitive = context.Options.HasFlag(ExpressionOptions.IgnoreCaseAtBuiltInFunctions);
         var comparison = caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;

--- a/src/NCalc.Async/Services/AsyncEvaluationService.cs
+++ b/src/NCalc.Async/Services/AsyncEvaluationService.cs
@@ -6,7 +6,7 @@ namespace NCalc.Services;
 /// <inheritdoc cref="IAsyncEvaluationService"/>
 public class AsyncEvaluationService : IAsyncEvaluationService
 {
-    public Task<object?> EvaluateAsync(LogicalExpression expression, AsyncExpressionContext context)
+    public ValueTask<object?> EvaluateAsync(LogicalExpression expression, AsyncExpressionContext context)
     {
         var visitor = new AsyncEvaluationVisitor(context);
         return expression.Accept(visitor);

--- a/src/NCalc.Async/Services/IAsyncEvaluationService.cs
+++ b/src/NCalc.Async/Services/IAsyncEvaluationService.cs
@@ -7,5 +7,5 @@ namespace NCalc.Services;
 /// </summary>
 public interface IAsyncEvaluationService
 {
-    Task<object?> EvaluateAsync(LogicalExpression expression, AsyncExpressionContext context);
+    ValueTask<object?> EvaluateAsync(LogicalExpression expression, AsyncExpressionContext context);
 }

--- a/src/NCalc.Async/Visitors/AsyncEvaluationVisitor.cs
+++ b/src/NCalc.Async/Visitors/AsyncEvaluationVisitor.cs
@@ -14,9 +14,9 @@ namespace NCalc.Visitors;
 /// Class responsible to asynchronous evaluating <see cref="LogicalExpression"/> objects into CLR objects.
 /// </summary>
 /// <param name="context">Contextual parameters of the <see cref="LogicalExpression"/>, like custom functions and parameters.</param>
-public class AsyncEvaluationVisitor(AsyncExpressionContext context) : ILogicalExpressionVisitor<Task<object?>>
+public class AsyncEvaluationVisitor(AsyncExpressionContext context) : ILogicalExpressionVisitor<ValueTask<object?>>
 {
-    public async Task<object?> Visit(TernaryExpression expression)
+    public async ValueTask<object?> Visit(TernaryExpression expression)
     {
         // Evaluates the left expression and saves the value
         var left = Convert.ToBoolean(await expression.LeftExpression.Accept(this), context.CultureInfo);
@@ -29,7 +29,7 @@ public class AsyncEvaluationVisitor(AsyncExpressionContext context) : ILogicalEx
         return expression.RightExpression.Accept(this);
     }
 
-    public async Task<object?> Visit(BinaryExpression expression)
+    public async ValueTask<object?> Visit(BinaryExpression expression)
     {
         var left = new Lazy<ValueTask<object?>>(() => EvaluateAsync(expression.LeftExpression),
             LazyThreadSafetyMode.None);
@@ -140,7 +140,7 @@ public class AsyncEvaluationVisitor(AsyncExpressionContext context) : ILogicalEx
         return null;
     }
 
-    public async Task<object?> Visit(UnaryExpression expression)
+    public async ValueTask<object?> Visit(UnaryExpression expression)
     {
         // Recursively evaluates the underlying expression
         var result = await expression.Expression.Accept(this);
@@ -148,7 +148,7 @@ public class AsyncEvaluationVisitor(AsyncExpressionContext context) : ILogicalEx
         return EvaluationHelper.Unary(expression, result, context);
     }
 
-    public async Task<object?> Visit(Function function)
+    public async ValueTask<object?> Visit(Function function)
     {
         var argsCount = function.Parameters.Count;
         var args = new AsyncExpression[argsCount];
@@ -179,7 +179,7 @@ public class AsyncEvaluationVisitor(AsyncExpressionContext context) : ILogicalEx
         return await AsyncBuiltInFunctionHelper.EvaluateAsync(functionName, args, context);
     }
 
-    public async Task<object?> Visit(Identifier identifier)
+    public async ValueTask<object?> Visit(Identifier identifier)
     {
         var identifierName = identifier.Name;
 
@@ -220,10 +220,10 @@ public class AsyncEvaluationVisitor(AsyncExpressionContext context) : ILogicalEx
         throw new NCalcParameterNotDefinedException(identifierName);
     }
 
-    public Task<object?> Visit(ValueExpression expression) => Task.FromResult(expression.Value);
+    public ValueTask<object?> Visit(ValueExpression expression) => new(expression.Value);
 
 
-    public async Task<object?> Visit(LogicalExpressionList list)
+    public async ValueTask<object?> Visit(LogicalExpressionList list)
     {
         List<object?> result = [];
 

--- a/test/NCalc.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/NCalc.Tests/ServiceCollectionExtensionsTests.cs
@@ -147,9 +147,9 @@ public class ServiceCollectionExtensionsTests
         public event AsyncEvaluateFunctionHandler EvaluateFunctionAsync;
         public event AsyncEvaluateParameterHandler EvaluateParameterAsync;
 
-        public Task<object> EvaluateAsync(LogicalExpression expression, AsyncExpressionContext context)
+        public ValueTask<object> EvaluateAsync(LogicalExpression expression, AsyncExpressionContext context)
         {
-            return Task.FromResult<object>(42);
+            return new(42);
         }
     }
     #endregion


### PR DESCRIPTION
Inspired by [Fluid](https://github.com/sebastienros/fluid) where they use the same pattern.

Makes sense for NCalc because most operations complete more sync than async.

Also, it's non-breaking in most cases, will be breaking only if someone is directly returning instead of awaiting the `Task` of an expression.