### PR TITLE
Fix compiler warnings in NCalc.Tests

### DIFF
--- a/test/NCalc.Tests/LambdaTests.cs
+++ b/test/NCalc.Tests/LambdaTests.cs
@@ -1,6 +1,6 @@
 ﻿#if NET8_0_OR_GREATER
+#nullable enable
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 
 // ReSharper disable MemberCanBeProtected.Local
 

--- a/test/NCalc.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/NCalc.Tests/ServiceCollectionExtensionsTests.cs
@@ -4,7 +4,6 @@ using NCalc.DependencyInjection;
 using NCalc.Domain;
 using NCalc.Exceptions;
 using NCalc.Factories;
-using NCalc.Handlers;
 using NCalc.Services;
 
 namespace NCalc.Tests;
@@ -131,9 +130,6 @@ public class ServiceCollectionExtensionsTests
 
     private class CustomEvaluationService : IEvaluationService
     {
-        public event EvaluateFunctionHandler EvaluateFunction;
-        public event EvaluateParameterHandler EvaluateParameter;
-
         public object Evaluate(LogicalExpression expression, ExpressionContext context)
         {
             return 42;
@@ -142,9 +138,6 @@ public class ServiceCollectionExtensionsTests
 
     private class CustomAsyncEvaluationService : IAsyncEvaluationService
     {
-        public event AsyncEvaluateFunctionHandler EvaluateFunctionAsync;
-        public event AsyncEvaluateParameterHandler EvaluateParameterAsync;
-
         public ValueTask<object> EvaluateAsync(LogicalExpression expression, AsyncExpressionContext context)
         {
             return new(42);


### PR DESCRIPTION
See details at https://github.com/ncalc/ncalc/actions/runs/10323026389

* The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
* The event 'ServiceCollectionExtensionsTests.CustomEvaluationService.EvaluateFunction' is never used
* The event 'ServiceCollectionExtensionsTests.CustomEvaluationService.EvaluateParameter' is never used
* The event 'ServiceCollectionExtensionsTests.CustomAsyncEvaluationService.EvaluateFunctionAsync' is never used
* The event 'ServiceCollectionExtensionsTests.CustomAsyncEvaluationService.EvaluateParameterAsync' is never used