### PR TITLE
Add "no string type coercion" option

### DIFF
--- a/src/NCalc.Core/ExpressionOptions.cs
+++ b/src/NCalc.Core/ExpressionOptions.cs
@@ -69,5 +69,10 @@ public enum ExpressionOptions
     /// <summary>
     /// Parse single quoted strings as <see cref="char"/>
     /// </summary>
-    AllowCharValues = 1 << 12
+    AllowCharValues = 1 << 12,
+
+    /// <summary>
+    /// Disables coercion of string values to other types
+    /// </summary>
+    NoStringTypeCoercion = 1 << 13,
 }

--- a/src/NCalc.Core/Helpers/EvaluationHelper.cs
+++ b/src/NCalc.Core/Helpers/EvaluationHelper.cs
@@ -20,6 +20,12 @@ public static class EvaluationHelper
         if (context.Options.HasFlag(ExpressionOptions.StringConcat))
             return string.Concat(leftValue, rightValue);
 
+        if (context.Options.HasFlag(ExpressionOptions.NoStringTypeCoercion) &&
+            (leftValue is string || rightValue is string))
+        {
+            return string.Concat(leftValue, rightValue);
+        }
+
         try
         {
             return MathHelper.Add(leftValue, rightValue, context);

--- a/test/NCalc.Tests/NoStringTypeCoercionTests.cs
+++ b/test/NCalc.Tests/NoStringTypeCoercionTests.cs
@@ -1,0 +1,21 @@
+namespace NCalc.Tests;
+
+[Trait("Category", "NoTypeCoercion")]
+public class NoStringTypeCoercionTests
+{
+    [Theory]
+    [InlineData("'to' + 'to'", "toto")]
+    [InlineData("'one' + 2", "one2")]
+    [InlineData("'one' + 2.1", "one2.1")]
+    [InlineData("2 + 'one'", "2one")]
+    [InlineData("2.1 + 'one'", "2.1one")]
+    [InlineData("'1' + '2'", "12")]
+    [InlineData("'1.1' + '2'", "1.12")]
+    [InlineData("'1' + '2.2'", "12.2")]
+    [InlineData("1 + 2", 3)]
+    [InlineData("1.5 + 2.5", 4.0)]
+    public void ShouldUseStringConcatenationIfEitherValueIsAString(string expression, object expected)
+    {
+        Assert.Equal(expected, new Expression(expression, ExpressionOptions.NoStringTypeCoercion).Evaluate());
+    }
+}

--- a/test/NCalc.Tests/NoStringTypeCoercionTests.cs
+++ b/test/NCalc.Tests/NoStringTypeCoercionTests.cs
@@ -14,6 +14,7 @@ public class NoStringTypeCoercionTests
     [InlineData("'1' + '2.2'", "12.2")]
     [InlineData("1 + 2", 3)]
     [InlineData("1.5 + 2.5", 4.0)]
+    [InlineData("'10' + 'mA - ' + (10 + 20) + 'mA'", "10mA - 30mA")]
     public void ShouldUseStringConcatenationIfEitherValueIsAString(string expression, object expected)
     {
         Assert.Equal(expected, new Expression(expression, ExpressionOptions.NoStringTypeCoercion).Evaluate());


### PR DESCRIPTION
This PR adds a new option `NoStringTypeCoercion`.

Currently by default NCalc will try to interpret strings like `"1"` as numbers when performing addition. This leads to some potentially unwanted behaviour. The option `StringConcat` was added to bypass this option by _always_ performing string concatenation, but this is also not always desirable.

With this new option enabled, strings are always interpreted as strings, which means with the `+` operator, string concatenation will _only_ be performed if _either_ value is a string.