### PR TITLE
Issue 335 parsing of large decimal literals

### DIFF
--- a/src/NCalc.Core/Parser/LogicalExpressionParser.cs
+++ b/src/NCalc.Core/Parser/LogicalExpressionParser.cs
@@ -84,42 +84,71 @@ public static class LogicalExpressionParser
                     long? decimalPart = x.Item3;
                     long? exponentPart = x.Item4;
 
-                    double result = integralValue;
-
-                    // decimal part?
-                    if (decimalPart != null && decimalPart.Value != 0)
-                    {
-                        var digits = Math.Floor(Math.Log10(decimalPart.Value) + 1) + zeroCount;
-                        result += decimalPart.Value / Math.Pow(10, digits);
-                    }
-
-                    // exponent part?
-                    if (exponentPart != null)
-                    {
-                        var left = BigDecimal.Parse(result);
-                        var right = BigDecimal.Pow(10, exponentPart.Value);
-
-                        var res = BigDecimal.Multiply(left, right);
-
-                        if (res > double.MaxValue)
-                            result = double.PositiveInfinity;
-                        else if (res < double.MinValue)
-                            result = double.NegativeInfinity;
-                        else
-                            result = (double)res;
-                    }
-
                     if (((LogicalExpressionParserContext)ctx).Options.HasFlag(ExpressionOptions.DecimalAsDefault))
                     {
-                        return new ValueExpression((decimal)result);
-                    }
+                        decimal result = (decimal)integralValue;
 
-                    if (decimalPart != null || exponentPart != null)
-                    {
+                        // decimal part?
+                        if (decimalPart != null && decimalPart.Value != 0)
+                        {
+                            var digits = Math.Floor(Math.Log10(decimalPart.Value) + 1) + zeroCount;
+                            result += (decimal)decimalPart.Value / (decimal)Math.Pow(10, digits);
+                        }
+
+                        // exponent part?
+                        if (exponentPart != null)
+                        {
+                            var left = BigDecimal.Parse((double)result);
+                            var right = BigDecimal.Pow(10, exponentPart.Value);
+
+                            var res = BigDecimal.Multiply(left, right);
+
+                            if (res > decimal.MaxValue)
+                                // There is no decimal.PositiveInfinity
+                                return new ValueExpression(double.PositiveInfinity);
+                            else if (res < decimal.MinValue)
+                                // There is no decimal.NegativeInfinity
+                                return new ValueExpression(double.NegativeInfinity);
+                            else
+                                result = (decimal)res;
+                        }
+
                         return new ValueExpression(result);
                     }
+                    else
+                    {
+                        double result = integralValue;
 
-                    return new ValueExpression((long)result);
+                        // decimal part?
+                        if (decimalPart != null && decimalPart.Value != 0)
+                        {
+                            var digits = Math.Floor(Math.Log10(decimalPart.Value) + 1) + zeroCount;
+                            result += decimalPart.Value / Math.Pow(10, digits);
+                        }
+
+                        // exponent part?
+                        if (exponentPart != null)
+                        {
+                            var left = BigDecimal.Parse(result);
+                            var right = BigDecimal.Pow(10, exponentPart.Value);
+
+                            var res = BigDecimal.Multiply(left, right);
+
+                            if (res > double.MaxValue)
+                                result = double.PositiveInfinity;
+                            else if (res < double.MinValue)
+                                result = double.NegativeInfinity;
+                            else
+                                result = (double)res;
+                        }
+
+                        if (decimalPart != null || exponentPart != null)
+                        {
+                            return new ValueExpression(result);
+                        }
+
+                        return new ValueExpression((long)result);
+                    }
                 });
 
         var comma = Terms.Char(',');

--- a/test/NCalc.Tests/DecimalsTests.cs
+++ b/test/NCalc.Tests/DecimalsTests.cs
@@ -3,14 +3,47 @@ namespace NCalc.Tests;
 [Trait("Category", "Decimals")]
 public class DecimalsTests
 {
-    [Fact]
-    public void Should_Use_Decimal_When_Configured()
+    [Theory]
+    // It's not possible to specify decimal literals in annotations, so here we use
+    // a string to specify the expected results, and parse it to a decimal in the test.
+    [InlineData("12.34", "12.34")]
+    [InlineData("12345678901234567890123456789",  "12345678901234567890123456789")]
+    [InlineData("0.1234567890123456789",          "0.1234567890123456789")]
+    [InlineData("10000000000000000.12",           "10000000000000000.12")]
+    [InlineData("100000000000000000000000000.12", "100000000000000000000000000.12")]
+    [InlineData("123456789012345678901234567.89", "123456789012345678901234567.89")]
+    [InlineData("1234567890.1234567890123456789", "1234567890.1234567890123456789")]
+    public void Should_Correctly_Parse_Large_Decimal_Literals_Issue_335(String expressionStr, String expectedDecimalResultStr)
     {
-        var expression = new Expression("12.34", ExpressionOptions.DecimalAsDefault);
+        // https://github.com/ncalc/ncalc/issues/335
+        var expectedDecimalResult = decimal.Parse(expectedDecimalResultStr);
+        // Ensure that decimal.Parse is working as presumed
+        Assert.Equal(expectedDecimalResult.ToString(), expectedDecimalResultStr);
 
+        var expression = new Expression(expressionStr, ExpressionOptions.DecimalAsDefault);
         var result = expression.Evaluate();
         Assert.IsType<decimal>(result);
-        Assert.Equal(12.34m, result);
+        Assert.Equal(expectedDecimalResult, result);
+    }
+
+    [Fact]
+    public void Should_Return_PositiveInfinity_When_Overflow_Issue_335()
+    {
+        // https://github.com/ncalc/ncalc/issues/335
+        var expression = new Expression("8E28", ExpressionOptions.DecimalAsDefault);
+        var result = expression.Evaluate();
+        Assert.IsType<double>(result);
+        Assert.Equal(double.PositiveInfinity, result);
+    }
+
+    [Fact]
+    public void Should_Return_NegativeInfinity_When_Overflow_Issue_335()
+    {
+        // https://github.com/ncalc/ncalc/issues/335
+        var expression = new Expression("-8E28", ExpressionOptions.DecimalAsDefault);
+        var result = expression.Evaluate();
+        Assert.IsType<double>(result);
+        Assert.Equal(double.NegativeInfinity, result);
     }
 
     [Fact]


### PR DESCRIPTION
A fix for https://github.com/ncalc/ncalc/issues/335

Large decimals expressed as literals are now correctly parsed (when ExpressionOptions.DecimalAsDefault is specified).

Added some tests to cover the new behavior.

You might find the diff easier to view if you ignore whitespace: https://github.com/ncalc/ncalc/pull/340/files?diff=unified&w=1
