### PR TITLE
Improve SerializationVisitor performance

### DIFF
--- a/src/NCalc.Core/NCalc.Core.csproj
+++ b/src/NCalc.Core/NCalc.Core.csproj
@@ -37,6 +37,7 @@
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Logging.TraceSource" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.10" />
         <PackageReference Include="Parlot" Version="1.0.2" />
     </ItemGroup>
 </Project>

--- a/src/NCalc.Core/Visitors/SerializationVisitor.cs
+++ b/src/NCalc.Core/Visitors/SerializationVisitor.cs
@@ -15,148 +15,130 @@ public class SerializationVisitor : ILogicalExpressionVisitor<string>
 
     public string Visit(TernaryExpression expression)
     {
-        var result = new StringBuilder();
-        result.Append(EncapsulateNoValue(expression.LeftExpression));
-        result.Append("? ");
-        result.Append(EncapsulateNoValue(expression.MiddleExpression));
-        result.Append(": ");
-        result.Append(EncapsulateNoValue(expression.RightExpression));
-        return result.ToString();
+        string result = EncapsulateNoValue(expression.LeftExpression) + "? ";
+        result += EncapsulateNoValue(expression.MiddleExpression) + ": ";
+        result += EncapsulateNoValue(expression.RightExpression);
+
+        return result;
     }
 
     public string Visit(BinaryExpression expression)
     {
-        var result = new StringBuilder();
-        result.Append(EncapsulateNoValue(expression.LeftExpression));
+        string result = EncapsulateNoValue(expression.LeftExpression);
 
         switch (expression.Type)
         {
             case BinaryExpressionType.And:
-                result.Append("and ");
+                result += "and ";
                 break;
             case BinaryExpressionType.Or:
-                result.Append("or ");
+                result += "or ";
                 break;
             case BinaryExpressionType.Div:
-                result.Append("/ ");
+                result += "/ ";
                 break;
             case BinaryExpressionType.Equal:
-                result.Append("= ");
+                result += "= ";
                 break;
             case BinaryExpressionType.Greater:
-                result.Append("> ");
+                result += "> ";
                 break;
             case BinaryExpressionType.GreaterOrEqual:
-                result.Append(">= ");
+                result += ">= ";
                 break;
             case BinaryExpressionType.Lesser:
-                result.Append("< ");
+                result += "< ";
                 break;
             case BinaryExpressionType.LesserOrEqual:
-                result.Append("<= ");
+                result += "<= ";
                 break;
             case BinaryExpressionType.Minus:
-                result.Append("- ");
+                result += "- ";
                 break;
             case BinaryExpressionType.Modulo:
-                result.Append("% ");
+                result += "% ";
                 break;
             case BinaryExpressionType.NotEqual:
-                result.Append("!= ");
+                result += "!= ";
                 break;
             case BinaryExpressionType.Plus:
-                result.Append("+ ");
+                result += "+ ";
                 break;
             case BinaryExpressionType.Times:
-                result.Append("* ");
+                result += "* ";
                 break;
             case BinaryExpressionType.BitwiseAnd:
-                result.Append("& ");
+                result += "& ";
                 break;
             case BinaryExpressionType.BitwiseOr:
-                result.Append("| ");
+                result += "| ";
                 break;
             case BinaryExpressionType.BitwiseXOr:
-                result.Append("^ ");
+                result += "^ ";
                 break;
             case BinaryExpressionType.LeftShift:
-                result.Append("<< ");
+                result += "<< ";
                 break;
             case BinaryExpressionType.RightShift:
-                result.Append(">> ");
+                result += ">> ";
                 break;
             case BinaryExpressionType.Exponentiation:
-                result.Append("** ");
+                result += "** ";
                 break;
             case BinaryExpressionType.In:
-                result.Append("in ");
+                result += "in ";
                 break;
             case BinaryExpressionType.NotIn:
-                result.Append("not in ");
+                result += "not in ";
                 break;
             case BinaryExpressionType.Like:
-                result.Append("like ");
+                result += "like ";
                 break;
             case BinaryExpressionType.NotLike:
-                result.Append("not like ");
+                result += "not like ";
                 break;
             case BinaryExpressionType.Unknown:
-                result.Append("unknown ");
+                result += "unknown ";
                 break;
             default:
                 throw new ArgumentOutOfRangeException();
         }
 
-        result.Append(EncapsulateNoValue(expression.RightExpression));
-        return result.ToString();
+        result += EncapsulateNoValue(expression.RightExpression);
+        return result;
     }
 
     public string Visit(UnaryExpression expression)
     {
-        var result = new StringBuilder();
+        string result = "";
 
         switch (expression.Type)
         {
             case UnaryExpressionType.Not:
-                result.Append('!');
+                result = "!";
                 break;
             case UnaryExpressionType.Negate:
-                result.Append('-');
+                result = "-";
                 break;
             case UnaryExpressionType.BitwiseNot:
-                result.Append('~');
+                result = "~";
                 break;
         }
 
-        result.Append(EncapsulateNoValue(expression.Expression));
-        return result.ToString();
+        result += EncapsulateNoValue(expression.Expression);
+        return result;
     }
 
     public string Visit(ValueExpression expression)
     {
-        var result = new StringBuilder();
-
-        switch (expression.Type)
+        return expression.Type switch
         {
-            case ValueType.Boolean:
-                result.Append(expression.Value).Append(' ');
-                break;
-            case ValueType.DateTime or ValueType.TimeSpan:
-                result.Append('#').Append(expression.Value).Append('#').Append(' ');
-                break;
-            case ValueType.Float:
-                result.Append(decimal.Parse(expression.Value?.ToString() ?? string.Empty).ToString(_numberFormatInfo))
-                    .Append(' ');
-                break;
-            case ValueType.Integer:
-                result.Append(expression.Value).Append(' ');
-                break;
-            case ValueType.String or ValueType.Char:
-                result.Append('\'').Append(expression.Value).Append('\'').Append(' ');
-                break;
-        }
-
-        return result.ToString();
+            ValueType.Boolean or ValueType.Integer => $"{expression.Value} ",
+            ValueType.DateTime or ValueType.TimeSpan => $"#{expression.Value}# ",
+            ValueType.Float => $"{decimal.Parse(expression.Value?.ToString() ?? string.Empty).ToString(_numberFormatInfo)} ",
+            ValueType.String or ValueType.Char => $"'{expression.Value}' ",
+            _ => "",
+        };
     }
 
     public string Visit(Function function)
@@ -183,9 +165,7 @@ public class SerializationVisitor : ILogicalExpressionVisitor<string>
 
     public string Visit(Identifier identifier)
     {
-        var result = new StringBuilder();
-        result.Append('[').Append(identifier.Name).Append("] ");
-        return result.ToString();
+        return $"[{identifier.Name}] ";
     }
 
     public string Visit(LogicalExpressionList list)
@@ -211,15 +191,7 @@ public class SerializationVisitor : ILogicalExpressionVisitor<string>
             return valueExpression.Accept(this);
         }
 
-        var result = new StringBuilder();
-        result.Append('(');
-        result.Append(expression.Accept(this));
-
-        // trim spaces before adding a closing paren
-        while (result[^1] == ' ')
-            result.Remove(result.Length - 1, 1);
-
-        result.Append(") ");
-        return result.ToString();
+        string result = expression.Accept(this);
+        return $"({result.TrimEnd(' ')}) ";
     }
 }

--- a/src/NCalc.Core/Visitors/SerializationVisitor.cs
+++ b/src/NCalc.Core/Visitors/SerializationVisitor.cs
@@ -15,130 +15,148 @@ public class SerializationVisitor : ILogicalExpressionVisitor<string>
 
     public string Visit(TernaryExpression expression)
     {
-        string result = EncapsulateNoValue(expression.LeftExpression) + "? ";
-        result += EncapsulateNoValue(expression.MiddleExpression) + ": ";
-        result += EncapsulateNoValue(expression.RightExpression);
-
-        return result;
+        var result = new StringBuilder();
+        result.Append(EncapsulateNoValue(expression.LeftExpression));
+        result.Append("? ");
+        result.Append(EncapsulateNoValue(expression.MiddleExpression));
+        result.Append(": ");
+        result.Append(EncapsulateNoValue(expression.RightExpression));
+        return result.ToString();
     }
 
     public string Visit(BinaryExpression expression)
     {
-        string result = EncapsulateNoValue(expression.LeftExpression);
+        var result = new StringBuilder();
+        result.Append(EncapsulateNoValue(expression.LeftExpression));
 
         switch (expression.Type)
         {
             case BinaryExpressionType.And:
-                result += "and ";
+                result.Append("and ");
                 break;
             case BinaryExpressionType.Or:
-                result += "or ";
+                result.Append("or ");
                 break;
             case BinaryExpressionType.Div:
-                result += "/ ";
+                result.Append("/ ");
                 break;
             case BinaryExpressionType.Equal:
-                result += "= ";
+                result.Append("= ");
                 break;
             case BinaryExpressionType.Greater:
-                result += "> ";
+                result.Append("> ");
                 break;
             case BinaryExpressionType.GreaterOrEqual:
-                result += ">= ";
+                result.Append(">= ");
                 break;
             case BinaryExpressionType.Lesser:
-                result += "< ";
+                result.Append("< ");
                 break;
             case BinaryExpressionType.LesserOrEqual:
-                result += "<= ";
+                result.Append("<= ");
                 break;
             case BinaryExpressionType.Minus:
-                result += "- ";
+                result.Append("- ");
                 break;
             case BinaryExpressionType.Modulo:
-                result += "% ";
+                result.Append("% ");
                 break;
             case BinaryExpressionType.NotEqual:
-                result += "!= ";
+                result.Append("!= ");
                 break;
             case BinaryExpressionType.Plus:
-                result += "+ ";
+                result.Append("+ ");
                 break;
             case BinaryExpressionType.Times:
-                result += "* ";
+                result.Append("* ");
                 break;
             case BinaryExpressionType.BitwiseAnd:
-                result += "& ";
+                result.Append("& ");
                 break;
             case BinaryExpressionType.BitwiseOr:
-                result += "| ";
+                result.Append("| ");
                 break;
             case BinaryExpressionType.BitwiseXOr:
-                result += "^ ";
+                result.Append("^ ");
                 break;
             case BinaryExpressionType.LeftShift:
-                result += "<< ";
+                result.Append("<< ");
                 break;
             case BinaryExpressionType.RightShift:
-                result += ">> ";
+                result.Append(">> ");
                 break;
             case BinaryExpressionType.Exponentiation:
-                result += "** ";
+                result.Append("** ");
                 break;
             case BinaryExpressionType.In:
-                result += "in ";
+                result.Append("in ");
                 break;
             case BinaryExpressionType.NotIn:
-                result += "not in ";
+                result.Append("not in ");
                 break;
             case BinaryExpressionType.Like:
-                result += "like ";
+                result.Append("like ");
                 break;
             case BinaryExpressionType.NotLike:
-                result += "not like ";
+                result.Append("not like ");
                 break;
             case BinaryExpressionType.Unknown:
-                result += "unknown ";
+                result.Append("unknown ");
                 break;
             default:
                 throw new ArgumentOutOfRangeException();
         }
 
-        result += EncapsulateNoValue(expression.RightExpression);
-        return result;
+        result.Append(EncapsulateNoValue(expression.RightExpression));
+        return result.ToString();
     }
 
     public string Visit(UnaryExpression expression)
     {
-        string result = "";
+        var result = new StringBuilder();
 
         switch (expression.Type)
         {
             case UnaryExpressionType.Not:
-                result = "!";
+                result.Append('!');
                 break;
             case UnaryExpressionType.Negate:
-                result = "-";
+                result.Append('-');
                 break;
             case UnaryExpressionType.BitwiseNot:
-                result = "~";
+                result.Append('~');
                 break;
         }
 
-        result += EncapsulateNoValue(expression.Expression);
-        return result;
+        result.Append(EncapsulateNoValue(expression.Expression));
+        return result.ToString();
     }
 
     public string Visit(ValueExpression expression)
     {
-        return expression.Type switch
+        var result = new StringBuilder();
+
+        switch (expression.Type)
         {
-            ValueType.Boolean or ValueType.Integer => $"{expression.Value} ",
-            ValueType.DateTime or ValueType.TimeSpan => $"#{expression.Value}# ",
-            ValueType.Float => $"{decimal.Parse(expression.Value?.ToString() ?? string.Empty).ToString(_numberFormatInfo)} ",
-            ValueType.String or ValueType.Char => $"'{expression.Value}' ",
-            _ => "",
-        };
+            case ValueType.Boolean:
+                result.Append(expression.Value).Append(' ');
+                break;
+            case ValueType.DateTime or ValueType.TimeSpan:
+                result.Append('#').Append(expression.Value).Append('#').Append(' ');
+                break;
+            case ValueType.Float:
+                result.Append(decimal.Parse(expression.Value?.ToString() ?? string.Empty).ToString(_numberFormatInfo))
+                    .Append(' ');
+                break;
+            case ValueType.Integer:
+                result.Append(expression.Value).Append(' ');
+                break;
+            case ValueType.String or ValueType.Char:
+                result.Append('\'').Append(expression.Value).Append('\'').Append(' ');
+                break;
+        }
+
+        return result.ToString();
     }
 
     public string Visit(Function function)
@@ -165,7 +183,9 @@ public class SerializationVisitor : ILogicalExpressionVisitor<string>
 
     public string Visit(Identifier identifier)
     {
-        return $"[{identifier.Name}] ";
+        var result = new StringBuilder();
+        result.Append('[').Append(identifier.Name).Append("] ");
+        return result.ToString();
     }
 
     public string Visit(LogicalExpressionList list)
@@ -191,7 +211,15 @@ public class SerializationVisitor : ILogicalExpressionVisitor<string>
             return valueExpression.Accept(this);
         }
 
-        string result = expression.Accept(this);
-        return $"({result.TrimEnd(' ')}) ";
+        var result = new StringBuilder();
+        result.Append('(');
+        result.Append(expression.Accept(this));
+
+        // trim spaces before adding a closing paren
+        while (result[^1] == ' ')
+            result.Remove(result.Length - 1, 1);
+
+        result.Append(") ");
+        return result.ToString();
     }
 }


### PR DESCRIPTION
This PR improves `SerializationVisitor` performance. 

I did some benchmarking and `StringBuilder` usage in some case is not the best solution, here some benchmark results:

```
[MemoryDiagnoser]
public class TestComparision
{
	public const string identifier = "identifier";

	[Benchmark(Baseline = true)]
	public string TestStringBuilder()
	{
		var result = new StringBuilder();
		result.Append('(');
		result.Append(identifier);

		// trim spaces before adding a closing paren
		while (result[^1] == ' ')
			result.Remove(result.Length - 1, 1);

		result.Append(") ");
		return result.ToString();
	}

	[Benchmark]
	public string TestStringConcat()
	{
		return "(" + identifier.TrimEnd(' ') + ") ";
	}

	[Benchmark]
	public string TestStringInterpolation()
	{
		return $"({identifier.TrimEnd(' ')}) ";
	}
}
```

BenchmarkDotNet v0.14.0, Windows 10 (10.0.19045.5011/22H2/2022Update)
Intel Core i3-6100U CPU 2.30GHz (Skylake), 1 CPU, 4 logical and 2 physical cores
.NET SDK 8.0.206
  [Host]     : .NET 6.0.35 (6.0.3524.45918), X64 RyuJIT AVX2
  DefaultJob : .NET 6.0.35 (6.0.3524.45918), X64 RyuJIT AVX2


| Method                  | Mean     | Error    | StdDev   | Median   | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|------------------------ |---------:|---------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
| TestStringBuilder       | 50.02 ns | 1.114 ns | 1.598 ns | 49.23 ns |  1.00 |    0.04 | 0.0969 |     152 B |        1.00 |
| TestStringConcat        | 26.80 ns | 0.228 ns | 0.190 ns | 26.74 ns |  0.54 |    0.02 | 0.0306 |      48 B |        0.32 |
| TestStringInterpolation | 27.64 ns | 0.625 ns | 1.647 ns | 26.73 ns |  0.55 |    0.04 | 0.0306 |      48 B |        0.32 |

  
```
[MemoryDiagnoser]
public class TestComparision
{
	public const string identifier = "identifier";

	[Benchmark(Baseline = true)]
	public string TestStringBuilderLoop()
	{
		var result = new StringBuilder();

		for (int i = 0; i < 5; i++)
			result.Append(identifier);

		return result.ToString();
	}

	[Benchmark]
	public string TestStringConcatLoop()
	{
		string str = "";
		for (int i = 0; i < 5; i++)
			str += identifier;

		return str;
	}
}
```
  BenchmarkDotNet v0.14.0, Windows 10 (10.0.19045.5011/22H2/2022Update)
Intel Core i3-6100U CPU 2.30GHz (Skylake), 1 CPU, 4 logical and 2 physical cores
.NET SDK 8.0.206
  [Host]     : .NET 6.0.35 (6.0.3524.45918), X64 RyuJIT AVX2
  DefaultJob : .NET 6.0.35 (6.0.3524.45918), X64 RyuJIT AVX2


| Method                | Mean      | Error    | StdDev   | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|---------------------- |----------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
| TestStringBuilderLoop | 195.10 ns | 2.659 ns | 2.487 ns |  1.00 |    0.02 | 0.3009 |     472 B |        1.00 |
| TestStringConcatLoop  |  97.86 ns | 1.128 ns | 0.881 ns |  0.50 |    0.01 | 0.2447 |     384 B |        0.81 |