### PR TITLE
Lambdas - add support for DecimalAsDefault

### DIFF
--- a/src/NCalc.Core/Helpers/MathFunctionHelper.cs
+++ b/src/NCalc.Core/Helpers/MathFunctionHelper.cs
@@ -4,43 +4,65 @@ namespace NCalc.Helpers;
 
 public static class MathFunctionHelper
 {
-    private static MathMethodInfo GetMathMethodInfo(string method, int argCount) => new()
+    private static List<MathMethodInfo> GetMathMethodInfo(string method, int argCount, bool supportDecimal = false)
     {
-        MethodInfo = typeof(Math).GetMethod(method, Enumerable.Repeat(typeof(double), argCount).ToArray())!,
-        ArgumentCount = argCount
-    };
+        var methodInfo = new List<MathMethodInfo>();
 
-    public static readonly FrozenDictionary<string, MathMethodInfo> Functions =
-        new Dictionary<string, MathMethodInfo>
+        if (supportDecimal)
         {
-            { "ABS", GetMathMethodInfo(nameof(Math.Abs), 1) },
+            methodInfo.Add(new MathMethodInfo()
+            {
+                MethodInfo = typeof(Math).GetMethod(method, Enumerable.Repeat(typeof(decimal), argCount).ToArray())!,
+                ArgumentCount = argCount,
+                DecimalSupport = true
+            });
+        }
+
+        methodInfo.Add(new MathMethodInfo()
+        {
+            MethodInfo = typeof(Math).GetMethod(method, Enumerable.Repeat(typeof(double), argCount).ToArray())!,
+            ArgumentCount = argCount,
+            DecimalSupport = false
+        });
+
+        return methodInfo;
+    }
+
+    public static readonly FrozenDictionary<string, List<MathMethodInfo>> Functions =
+        new Dictionary<string, List<MathMethodInfo>>
+        {
+            { "ABS", GetMathMethodInfo(nameof(Math.Abs), 1, true) },
             { "ACOS", GetMathMethodInfo(nameof(Math.Acos), 1) },
             { "ASIN", GetMathMethodInfo(nameof(Math.Asin), 1) },
             { "ATAN", GetMathMethodInfo(nameof(Math.Atan), 1) },
             { "ATAN2", GetMathMethodInfo(nameof(Math.Atan2), 2) },
-            { "CEILING", GetMathMethodInfo(nameof(Math.Ceiling), 1) },
+            { "CEILING", GetMathMethodInfo(nameof(Math.Ceiling), 1, true) },
             { "COS", GetMathMethodInfo(nameof(Math.Cos), 1) },
             { "COSH", GetMathMethodInfo(nameof(Math.Cosh), 1) },
             { "EXP", GetMathMethodInfo(nameof(Math.Exp), 1) },
-            { "FLOOR", GetMathMethodInfo(nameof(Math.Floor), 1) },
+            { "FLOOR", GetMathMethodInfo(nameof(Math.Floor), 1, true) },
             { "IEEEREMAINDER", GetMathMethodInfo(nameof(Math.IEEERemainder), 2) },
             { "LOG", GetMathMethodInfo(nameof(Math.Log), 2) },
             { "LOG10", GetMathMethodInfo(nameof(Math.Log10), 1) },
-            { "SIGN", GetMathMethodInfo(nameof(Math.Sign), 1) },
+            { "SIGN", GetMathMethodInfo(nameof(Math.Sign), 1, true) },
             { "SIN", GetMathMethodInfo(nameof(Math.Sin), 1) },
             { "SINH", GetMathMethodInfo(nameof(Math.Sinh), 1) },
             { "SQRT", GetMathMethodInfo(nameof(Math.Sqrt), 1) },
             { "TAN", GetMathMethodInfo(nameof(Math.Tan), 1) },
             { "TANH", GetMathMethodInfo(nameof(Math.Tanh), 1) },
-            { "TRUNCATE", GetMathMethodInfo(nameof(Math.Truncate), 1) },
+            { "TRUNCATE", GetMathMethodInfo(nameof(Math.Truncate), 1, true) },
 
             // Exceptional handling
             {
-                "ROUND", new MathMethodInfo
+                "ROUND", new List<MathMethodInfo>()
                 {
-                    MethodInfo = typeof(Math).GetMethod(nameof(Math.Round),
-                        [typeof(double), typeof(int), typeof(MidpointRounding)])!,
-                    ArgumentCount = 2
+                    new MathMethodInfo()
+                    {
+                        MethodInfo = typeof(Math).GetMethod(nameof(Math.Round),
+                            [typeof(double), typeof(int), typeof(MidpointRounding)])!,
+                        ArgumentCount = 2,
+                        DecimalSupport = false
+                    }
                 }
             }
         }.ToFrozenDictionary();

--- a/src/NCalc.Core/Helpers/MathMethodInfo.cs
+++ b/src/NCalc.Core/Helpers/MathMethodInfo.cs
@@ -6,4 +6,5 @@ public readonly struct MathMethodInfo
 {
     public required MethodInfo MethodInfo { get; init; }
     public required int ArgumentCount { get; init; }
+    public required bool DecimalSupport { get; init; }
 }

--- a/test/NCalc.Tests/LambdaTests.cs
+++ b/test/NCalc.Tests/LambdaTests.cs
@@ -650,5 +650,55 @@ public class LambdaTests
         var lambda = e.ToLambda<decimal>();
         Assert.Equal(9.61m, lambda());
     }
+
+    [Fact]
+    public void ShouldUseDecimalsWithDecimalAsDefault()
+    {
+        decimal val = 3.1m;
+
+        // Arrange
+        var expressionAbs = new Expression("Abs(x)", ExpressionOptions.DecimalAsDefault);
+        expressionAbs.Parameters["x"] = val;
+        var lambdaAbs = expressionAbs.ToLambda<decimal>();
+
+        var expressionCeiling = new Expression("Ceiling(x)", ExpressionOptions.DecimalAsDefault);
+        expressionCeiling.Parameters["x"] = val;
+        var lambdaCeiling = expressionCeiling.ToLambda<decimal>();
+
+        var expressionFloor = new Expression("Floor(x)", ExpressionOptions.DecimalAsDefault);
+        expressionFloor.Parameters["x"] = val;
+        var lambdaFloor = expressionFloor.ToLambda<decimal>();
+
+        var expressionSign = new Expression("Sign(x)", ExpressionOptions.DecimalAsDefault);
+        expressionSign.Parameters["x"] = val;
+        var lambdaSign = expressionSign.ToLambda<decimal>();
+
+        var expressionTruncate = new Expression("Truncate(x)", ExpressionOptions.DecimalAsDefault);
+        expressionTruncate.Parameters["x"] = val;
+        var lambdaTruncate = expressionTruncate.ToLambda<decimal>();
+
+        // Act
+        var actualAbs = lambdaAbs();
+        var expectedAbs = Math.Abs(val);
+
+        var actualCeiling = lambdaCeiling();
+        var expectedCeiling = Math.Ceiling(val);
+
+        var actualFloor = lambdaFloor();
+        var expectedFloor = Math.Floor(val);
+
+        var actualSign = lambdaSign();
+        var expectedSign = Math.Sign(val);
+
+        var actualTruncate = lambdaTruncate();
+        var expectedTruncate = Math.Truncate(val);
+
+        // Assert
+        Assert.Equal(expectedAbs, actualAbs);
+        Assert.Equal(expectedCeiling, actualCeiling);
+        Assert.Equal(expectedFloor, actualFloor);
+        Assert.Equal(expectedSign, actualSign);
+        Assert.Equal(expectedTruncate, actualTruncate);
+    }
 }
 #endif


### PR DESCRIPTION
Add support for `ExpressionOptions.DecimalAsDefault` in lambdas.