### PR TITLE
Fix Directory.Build.props inheritance

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
-    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+    <Import Project="$(MSBuildThisFileDirectory)../Directory.Build.props" />
     <PropertyGroup>
         <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
         <LangVersion>13</LangVersion>

--- a/src/Plugins/Directory.build.props
+++ b/src/Plugins/Directory.build.props
@@ -1,5 +1,5 @@
 <Project>
-    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../../'))" />
+    <Import Project="$(MSBuildThisFileDirectory)../Directory.Build.props" />
     
     <PropertyGroup>
         <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
On my machine nothing would build because the `Directory.Build.props` file were not imported. This fixed it.