### PR TITLE
Add binary, octal and hexadecimal number support.

### DIFF
--- a/src/NCalc.Core/Parser/LogicalExpressionParser.cs
+++ b/src/NCalc.Core/Parser/LogicalExpressionParser.cs
@@ -69,6 +69,18 @@ public static class LogicalExpressionParser
                             }))
                         .And(exponentNumberPart)
                         .Then(x => (0L, x.Item1.Item1, x.Item1.Item2, x.Item2)),
+                    Literals.Text("0x")
+                        .SkipAnd(Terms.Pattern(c => "0123456789abcdefABCDEF".Contains(c)))
+                        .Then(x => Convert.ToInt64(x.ToString(), 16))
+                        .Then<(long, int, long?, long?)>(x => (x, 0, null, null)),
+                    Literals.Text("0b")
+                        .SkipAnd(Terms.Pattern(c => c == '0' || c == '1'))
+                        .Then(x => Convert.ToInt64(x.ToString(), 2))
+                        .Then<(long, int, long?, long?)>(x => (x, 0, null, null)),
+                    Literals.Text("0o")
+                        .SkipAnd(Terms.Pattern(c => "01234567".Contains(c)))
+                        .Then(x => Convert.ToInt64(x.ToString(), 8))
+                        .Then<(long, int, long?, long?)>(x => (x, 0, null, null)),
                     Literals.Integer()
                         .And(Literals.Char('.')
                             .SkipAnd(ZeroOrMany(Literals.Char('0')).ThenElse(x => x.Count, 0))

--- a/test/NCalc.Tests/DecimalsTests.cs
+++ b/test/NCalc.Tests/DecimalsTests.cs
@@ -139,4 +139,25 @@ public class DecimalsTests
         var e2 = new Expression("Pow(3.1, 2)", ExpressionOptions.DecimalAsDefault);
         Assert.Equal(9.61m, e2.Evaluate());
     }
+
+    [Fact]
+    public void ShouldResolveHexadecimal()
+    {
+        Assert.Equal(0x2f, new Expression("0x17 + 0x18").Evaluate());
+    }
+
+    
+    [Fact]
+    public void ShouldResolveOctal()
+    {
+        Assert.Equal(29, new Expression("0o16 + 0o17").Evaluate());
+    }
+    
+    [Fact]
+    public void ShouldResolveBinary()
+    {
+        Assert.Equal(255, new Expression("0b00001111 + 0b11110000").Evaluate());
+        Assert.Equal(0UL, new Expression("0b00001111 & 0b11110000").Evaluate());
+        Assert.Equal(255UL, new Expression("0b00001111 | 0b11110000").Evaluate());
+    }
 }


### PR DESCRIPTION
You can use binary, octal, hexadecimal number in expression, such as `0xad`, `0o17`, `0b0110`.

LIMIT: the value will be translate to `long`, so you cannot set the value large then `long.MaxValue`.