### PR TITLE
Documentation - Broken Links & Formatting

### DIFF
--- a/docs/articles/architecture.md
+++ b/docs/articles/architecture.md
@@ -40,10 +40,10 @@ The method <xref:NCalc.Expression.Evaluate> returns the actual value of its <xre
 Example:
 
 ```c#
-  var expression = new Expression("2 * 3");
-  var result = expression.Evaluate();
+var expression = new Expression("2 * 3");
+var result = expression.Evaluate();
   
-  Console.WriteLine(result);
+Console.WriteLine(result);
 ```
 
 This example above first creates an instance of <xref:NCalc.Expression> using a valued constructor. This constructor

--- a/docs/articles/caching.md
+++ b/docs/articles/caching.md
@@ -5,16 +5,16 @@ When <xref:NCalc.Expression.Evaluate> is called on an expression, it is parsed o
 Moreover, each parsed expression is cached internally, which means you don't even have to care about reusing an <xref:NCalc.Expression> instance, the framework will do it for you.
 The cache is automatically cleaned like the GC does when an Expression is no more used, or memory is needed (i.e. using [WeakReference<LogicalExpression>](https://learn.microsoft.com/en-us/dotnet/api/system.weakreference-1?view=net-8.0)).
 
-You can disable this behavior at the framework level by adding <xref:NCalc.Core.ExpressionOptions.NoCache> at your [global expression context](expression_context.md).
+You can disable this behavior at the framework level by adding <xref:NCalc.ExpressionOptions.NoCache> at your [global expression context](expression_context.md).
 
 ```c#
- MyContext.Value.Options = ExpressionOptions.NoCache;
+MyContext.Value.Options = ExpressionOptions.NoCache;
 ```
 
 You can also tell a specific <xref:NCalc.Expression> instance not to be taken from the cache.
 
 ```c#
- var expression = new Expression("1 + 1", ExpressionOptions.NoCache);
+var expression = new Expression("1 + 1", ExpressionOptions.NoCache);
 ```
 
 You can customize the cache implementation using [Dependency Injection](dependency_injection.md).

--- a/docs/articles/case_sensitivity.md
+++ b/docs/articles/case_sensitivity.md
@@ -36,11 +36,11 @@ var expression = new Expression("aBs(-1)", ExpressionOptions.IgnoreCaseAtBuiltIn
 You can also change the comparison of string values using <xref:NCalc.ExpressionOptions.CaseInsensitiveStringComparer>.
 
 ```c#
- var expression = new Expression("{PageState} == 'list'");
- expression.Parameters["PageState"] = "List";
- Debug.Assert(false, expression.Evaluate());
- 
- expression = new Expression("{PageState} == 'list'", ExpressionOptions.CaseInsensitiveStringComparer);
- expression.Parameters["PageState"] = "List";
- Debug.Assert(true, expression.Evaluate());
+var expression = new Expression("{PageState} == 'list'");
+expression.Parameters["PageState"] = "List";
+Debug.Assert(false, expression.Evaluate());
+
+expression = new Expression("{PageState} == 'list'", ExpressionOptions.CaseInsensitiveStringComparer);
+expression.Parameters["PageState"] = "List";
+Debug.Assert(true, expression.Evaluate());
 ```

--- a/docs/articles/functions.md
+++ b/docs/articles/functions.md
@@ -40,8 +40,6 @@ You can use comma (,) or semicolon (;) as argument separator.
 
 If <xref:NCalc.ExpressionOptions.DecimalAsDefault> is used all functions will cast the arguments to <xref:System.Decimal>.
 
-You can get the functions from the <xref:NCalc.ExpressionBuiltInFuctions> class.
-
 ## Custom Functions
 Custom functions are created using the <xref:NCalc.ExpressionFunction> delegate. The parameters are <xref:NCalc.Expression> instances that can be lazy evaluated.
 ```csharp
@@ -55,10 +53,10 @@ expression.Functions["SecretOperation"] = (args) => {
 You can also use event handlers to handle functions.
 ```csharp
 expression.EvaluateFunction += delegate(string name, FunctionArgs args)
-    {
-        if (name == "SecretOperation")
-            args.Result = (int)args.Parameters[0].Evaluate() + (int)args.Parameters[1].Evaluate();
-    };
+{
+    if (name == "SecretOperation")
+        args.Result = (int)args.Parameters[0].Evaluate() + (int)args.Parameters[1].Evaluate();
+};
 ```
 
 ## Case Sensitivity

--- a/docs/articles/handling_errors.md
+++ b/docs/articles/handling_errors.md
@@ -5,7 +5,7 @@ When the expression has a syntax error, the evaluation will throw a <xref:NCalc.
 ```c#
 try
 {
- new Expression("(3 + 2").Evaluate();
+    new Expression("(3 + 2").Evaluate();
 }
 catch (NCalcParserException ex)
 {
@@ -17,12 +17,12 @@ catch (NCalcEvaluationException ex)
 }
 ```
 
-Though, you can also detect syntax errors before the evaluation by using the <xref:NCalc.Expression.HasErrors> method.
+Though, you can also detect syntax errors before the evaluation by using the <xref:NCalc.ExpressionBase`1.HasErrors> method.
 
 ```c#
- var expression = new Expression("a + b * (");
- if(expression.HasErrors())
- {
-     Console.WriteLine(expression.Error);
- }
+var expression = new Expression("a + b * (");
+if(expression.HasErrors())
+{
+    Console.WriteLine(expression.Error);
+}
 ```

--- a/docs/articles/lambda_compilation.md
+++ b/docs/articles/lambda_compilation.md
@@ -22,13 +22,13 @@ Debug.Assert(function()); //3
 ```c#
 class Context
 {
-  public int Param1 { get; set; }
-  public string Param2 { get; set; }
+    public int Param1 { get; set; }
+    public string Param2 { get; set; }
   
-  public int Foo(int a, int b)
-  {
-    return a + b;
-  }
+    public int Foo(int a, int b)
+    {
+        return a + b;
+    }
 }
 
 var expression = new Expression("Foo([Param1], 2) = 4 && [Param2] = 'test'");
@@ -39,5 +39,5 @@ Debug.Assert(function(context)); //true
 ```
 
 ## Performance
-You should cache the result of <xref:NCalc.Expression.ToLambda`1>. The evaluation is indeed faster, but the compilation of the lambda is very slow.
+You should cache the result of <xref:NCalc.Expression.ToLambda``1>. The evaluation is indeed faster, but the compilation of the lambda is very slow.
 See [benchmarks](benchmarks.md) for more info.

--- a/docs/articles/overflow_protection.md
+++ b/docs/articles/overflow_protection.md
@@ -5,7 +5,7 @@ To handle binary arithmetic operation overflow you should use <xref:NCalc.Expres
 ```c#
 try
 {
-   var expression = new Expression($"{int.MaxValue} + 1", ExpressionOptions.OverflowProtection);
+    var expression = new Expression($"{int.MaxValue} + 1", ExpressionOptions.OverflowProtection);
 }
 catch (OverflowException ex) { }
 ```

--- a/docs/articles/parameters.md
+++ b/docs/articles/parameters.md
@@ -3,15 +3,15 @@
 ## Static parameters
 
 Static parameters are values which can be defined before the evaluation of an expression.
-These parameters can be accessed using the <xref:NCalc.Expression.Parameters> property of the <xref:NCalc.Expression>
+These parameters can be accessed using the <xref:NCalc.ExpressionBase`1.Parameters> property of the <xref:NCalc.Expression>
 instance.
 
 ```c#
-  var expression = new Expression("2 * [x] ^ 2 + 5 * [y]");
-  expression.Parameters["x"] = 5;
-  expression.Parameters["y"] = 1;
+var expression = new Expression("2 * [x] ^ 2 + 5 * [y]");
+expression.Parameters["x"] = 5;
+expression.Parameters["y"] = 1;
 
-  Console.WriteLine(expression.Evaluate());
+Console.WriteLine(expression.Evaluate());
 ```
 
 Parameters can be useful when a value is unknown at compile time, or when performance is important and the parsing can
@@ -23,11 +23,11 @@ Expressions can be split into several ones by defining expression parameters. Th
 <xref:NCalc.Expression> instances themselves.
 
 ```c#
-  Expression volume = new Expression("[surface] * h");
-  Expression surface = new Expression("[l] * [L]");
-  volume.Parameters["surface"] = surface;
-  surface.Parameters["l"] = 1;
-  surface.Parameters["L"] = 2;
+Expression volume = new Expression("[surface] * h");
+Expression surface = new Expression("[l] * [L]");
+volume.Parameters["surface"] = surface;
+surface.Parameters["l"] = 1;
+surface.Parameters["L"] = 2;
 ```
 
 ## Dynamic parameters
@@ -36,10 +36,10 @@ Sometimes parameters can be even more complex to evaluate and need a dedicated m
 using the <xref:NCalc.ExpressionParameter> delegate.
 
 ```c#
-  var expression = new Expression("Round(Pow([Pi], 2) + Pow([Pi], 2) + [X], 2)");
+var expression = new Expression("Round(Pow([Pi], 2) + Pow([Pi], 2) + [X], 2)");
 
-  expression.Parameters["Pi2"] = new Expression("Pi * [Pi]");
-  expression.Parameters["X"] = 10;
+expression.Parameters["Pi2"] = new Expression("Pi * [Pi]");
+expression.Parameters["X"] = 10;
 
 expression.DynamicParameters["Pi"] = _ => {
     Console.WriteLine("I'm evaluating π!");
@@ -52,7 +52,7 @@ expression.DynamicParameters["Pi"] = _ => {
 Parameters in between square brackets can contain special characters like spaces, dots, and also start with digits.
 
 ```c#
-  var expression = new Expression("[My First Parameter] + [My Second Parameter]");
+var expression = new Expression("[My First Parameter] + [My Second Parameter]");
 ```
 
 ## Curly braces parameters
@@ -60,7 +60,7 @@ Parameters in between square brackets can contain special characters like spaces
 You can also use a curly braces as alternative to square brackets.
 
 ```c#
-  var expression = new Expression("{PageState} ==  'List'");
+var expression = new Expression("{PageState} ==  'List'");
 ```
 
 ## Multi-valued parameters
@@ -69,31 +69,31 @@ When parameters are `IEnumerable` and the <xref:NCalc.ExpressionOptions.IterateP
 used, the result is a `List<object?>` made of the evaluation of each value in the parameter.
 
 ```c#
- var expression = new Expression("(a * b) ^ c", ExpressionOptions.IterateParameters);
- expression.Parameters["a"] = new int[] { 1, 2, 3, 4, 5 };
- expression.Parameters["b"] = new int[] { 6, 7, 8, 9, 0 };
- expression.Parameters["c"] = 3;
+var expression = new Expression("(a * b) ^ c", ExpressionOptions.IterateParameters);
+expression.Parameters["a"] = new int[] { 1, 2, 3, 4, 5 };
+expression.Parameters["b"] = new int[] { 6, 7, 8, 9, 0 };
+expression.Parameters["c"] = 3;
 
- foreach (var result in (IList)expression.Evaluate())
- {
-     Console.WriteLine(result);
- }
+foreach (var result in (IList)expression.Evaluate())
+{
+    Console.WriteLine(result);
+}
 
- //  216
- //  2744
- //  13824
- //  46656
- //  0
+//  216
+//  2744
+//  13824
+//  46656
+//  0
 ```
 
 ## Using Event Handlers
 You can also use event handlers to handle parameters.
 ```csharp
 expression.EvaluateParameter += delegate(string name, ParameterArgs args)
-  {
+{
     if (name == "Pi")
         args.Result = 3.14;
-  };
+};
 ```
 
 ## Compare with null parameters
@@ -105,18 +105,18 @@ allowed.
 var expression = new Expression("'a string' == null", ExpressionOptions.AllowNullParameter);
 (bool)expression.Evaluate();
 
- //  False
+//  False
 ```
 
 ## Getting all parameters from an expression
 
 ```c#
-	var expression = new Expression ("if(x=0,x,y)"); 
-    expression.Parameters["x"] = 1;
-    expression.Parameters["y"] = "pan"
-    var parameters = expression.GetParametersNames(); 
- //  x
- //  y
+var expression = new Expression ("if(x=0,x,y)"); 
+expression.Parameters["x"] = 1;
+expression.Parameters["y"] = "pan";
+var parameters = expression.GetParametersNames(); 
+//  x
+//  y
 ```
 
 ## Case Sensitivity

--- a/docs/articles/strict_type_matching.md
+++ b/docs/articles/strict_type_matching.md
@@ -5,12 +5,12 @@ With `StrictTypeMatching`, expressions comparing incompatible types (e.g., `stri
 ## Usage Example
 
 ```csharp
-var expression = new Expression("'1' == 1", ExpressionOptions.StrictTypeMatching) 
+var expression = new Expression("'1' == 1", ExpressionOptions.StrictTypeMatching);
 Debug.Assert(false, expression.Evaluate()); //Without ExpressionOptions.StrictTypeMatching, this would be true.
 ```
 
 It is especially useful in expressions like this that would throw an exception:
 ```csharp
-var expression = new Expression("'' == 1", ExpressionOptions.StrictTypeMatching) 
+var expression = new Expression("'' == 1", ExpressionOptions.StrictTypeMatching);
 Debug.Assert(false, expression.Evaluate()); //Without ExpressionOptions.StrictTypeMatching, this would throw an exception.
 ```

--- a/docs/articles/values.md
+++ b/docs/articles/values.md
@@ -83,7 +83,7 @@ greeting("Chers")
 You can escape special characters using \\, \', \n, \r, \t.
 
 ## Chars
-If you use <xref:ExpressionOptions.AllowCharValues>, single quoted strings are interpreted as <xref:System.Char>
+If you use <xref:NCalc.ExpressionOptions.AllowCharValues>, single quoted strings are interpreted as <xref:System.Char>
 ```
 var expression = new Expression("'g'", ExpressionOptions.AllowCharValues);
 var result = expression.Evalutate();
@@ -102,7 +102,7 @@ getUser(78b1941f4e7941c9bef656fad7326538)
 A function is made of a name followed by braces, containing optionally any value as arguments.
 
 ```
-  Abs(1)
+Abs(1)
 ```
 
 ```
@@ -116,7 +116,7 @@ Please read the [functions page](functions.md) for details.
 A parameter as a name, and can be optionally contained inside brackets or double quotes.
 
 ```
-  2 + x, 2 + [x]
+2 + x, 2 + [x]
 ```
 
 Please read the [parameters page](parameters.md) for details.


### PR DESCRIPTION
I noticed some broken links in the documentation so I fixed those along with a couple of minor issues I ran across.

## XRef/Broken Links
- Removed XReference to BuiltInFunctions in Functions.md - this class doesn't seem to exist (if there is a way to get a list of built in functions I couldn't find let me know)
- Updated Parameters references in Parameters.md - It is part of ExpressionBase, not Expression

## Codeblocks spacing
- Codeblocks have inconsistent spacing at the start of lines
- Maybe a pedantic fix, but some articles e.g. [Parameters](https://ncalc.github.io/ncalc/articles/parameters.html) with a lot of code blocks look a lot more polished with added consistency
- The article/index.md has no spacing at the start of the first line of code in a code block, and 4 spaces for each indent so I copied that formatting and standardised code blocks I came across

## Code corrections
- Parameters.md - added missing semi-colon to end of code line