### PR TITLE
Use CultureInfo in string concatenation

### DIFF
--- a/src/NCalc.Core/Helpers/EvaluationHelper.cs
+++ b/src/NCalc.Core/Helpers/EvaluationHelper.cs
@@ -19,7 +19,9 @@ public static class EvaluationHelper
     public static object? Plus(object? leftValue, object? rightValue, ExpressionContextBase context)
     {
         if (context.Options.HasFlag(ExpressionOptions.StringConcat))
-            return string.Concat(leftValue, rightValue);
+            return string.Concat(
+                Convert.ToString(leftValue, context.CultureInfo),
+                Convert.ToString(rightValue, context.CultureInfo));
 
         if (context.Options.HasFlag(ExpressionOptions.NoStringTypeCoercion) &&
             (leftValue is string || rightValue is string))
@@ -33,7 +35,9 @@ public static class EvaluationHelper
         }
         catch (FormatException) when (leftValue is string && rightValue is string)
         {
-            return string.Concat(leftValue, rightValue);
+            return string.Concat(
+                Convert.ToString(leftValue, context.CultureInfo),
+                Convert.ToString(rightValue, context.CultureInfo));
         }
     }
 

--- a/test/NCalc.Tests/CustomCultureTests.cs
+++ b/test/NCalc.Tests/CustomCultureTests.cs
@@ -9,7 +9,7 @@ public class CustomCultureTests
         var cultureDot = (CultureInfo)CultureInfo.InvariantCulture.Clone();
         cultureDot.NumberFormat.NumberGroupSeparator = " ";
         var cultureComma = (CultureInfo)CultureInfo.InvariantCulture.Clone();
-        cultureComma.NumberFormat.CurrencyDecimalSeparator = ",";
+        cultureComma.NumberFormat.NumberDecimalSeparator = ",";
         cultureComma.NumberFormat.NumberGroupSeparator = " ";
 
         //use 1*[A] to avoid evaluating expression parameters as string - force numeric conversion
@@ -37,8 +37,8 @@ public class CustomCultureTests
             {
                 Parameters =
                 {
-                    {"A","2.0"},
-                    {"B","0.5"}
+                    {"A","2,0"},
+                    {"B","0,5"}
                 }
             }.Evaluate());
 
@@ -89,6 +89,29 @@ public class CustomCultureTests
             var e = new Expression("[a]<2.0", CultureInfo.InvariantCulture);
             e.Parameters["a"] = "1.7";
             Assert.Equal(true, e.Evaluate());
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentCulture = originalCulture;
+        }
+    }
+    [Fact]
+    public void ShouldConvertToStringUsingCultureInfo()
+    {
+        var originalCulture = (CultureInfo)Thread.CurrentThread.CurrentCulture.Clone();
+        try
+        {
+            var culture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+            culture.NumberFormat.NumberDecimalSeparator = ",";
+            Thread.CurrentThread.CurrentCulture = culture;
+            var context = new ExpressionContext(
+                ExpressionOptions.StringConcat,
+                CultureInfo.InvariantCulture);
+            var expr = new Expression("[a] + 2.5", context)
+            {
+                Parameters = { ["a"] = 1.7 }
+            };
+            Assert.Equal("1.72.5", expr.Evaluate());
         }
         finally
         {

--- a/test/NCalc.Tests/CustomCultureTests.cs
+++ b/test/NCalc.Tests/CustomCultureTests.cs
@@ -9,7 +9,7 @@ public class CustomCultureTests
         var cultureDot = (CultureInfo)CultureInfo.InvariantCulture.Clone();
         cultureDot.NumberFormat.NumberGroupSeparator = " ";
         var cultureComma = (CultureInfo)CultureInfo.InvariantCulture.Clone();
-        cultureComma.NumberFormat.NumberDecimalSeparator = ",";
+        cultureComma.NumberFormat.CurrencyDecimalSeparator = ",";
         cultureComma.NumberFormat.NumberGroupSeparator = " ";
 
         //use 1*[A] to avoid evaluating expression parameters as string - force numeric conversion
@@ -37,8 +37,8 @@ public class CustomCultureTests
             {
                 Parameters =
                 {
-                    {"A","2,0"},
-                    {"B","0,5"}
+                    {"A","2.0"},
+                    {"B","0.5"}
                 }
             }.Evaluate());
 


### PR DESCRIPTION
This fixes the specific problem outlined in #391, but I don't know if there are more cases where culture info might be ignored.