### PR TITLE
Fix comparing values with `null`

### DIFF
--- a/src/NCalc.Async/Visitors/AsyncEvaluationVisitor.cs
+++ b/src/NCalc.Async/Visitors/AsyncEvaluationVisitor.cs
@@ -251,6 +251,9 @@ public class AsyncEvaluationVisitor(AsyncExpressionContext context) : ILogicalEx
         if (context.Options.HasFlag(ExpressionOptions.StrictTypeMatching) && a?.GetType() != b?.GetType())
             return false;
 
+        if ((a == null || b == null) && !(a == null && b == null))
+            return false;
+
         var result = CompareUsingMostPreciseType(a, b, context);
 
         return comparisonType switch

--- a/src/NCalc.Sync/Visitors/EvaluationVisitor.cs
+++ b/src/NCalc.Sync/Visitors/EvaluationVisitor.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using NCalc.Domain;
+﻿using NCalc.Domain;
 using NCalc.Exceptions;
 using NCalc.Handlers;
 using NCalc.Helpers;
@@ -232,6 +231,9 @@ public class EvaluationVisitor(ExpressionContext context) : ILogicalExpressionVi
     protected bool Compare(object? a, object? b, ComparisonType comparisonType)
     {
         if (context.Options.HasFlag(ExpressionOptions.StrictTypeMatching) && a?.GetType() != b?.GetType())
+            return false;
+
+        if ((a == null || b == null) && !(a == null && b == null))
             return false;
 
         var result = CompareUsingMostPreciseType(a, b, context);

--- a/test/NCalc.Tests/ComparerTests.cs
+++ b/test/NCalc.Tests/ComparerTests.cs
@@ -100,4 +100,15 @@ public class ComparerTests
         var ex = Assert.Throws<NCalcParameterNotDefinedException>(() => e.Evaluate());
         Assert.Contains("not defined", ex.Message);
     }
+
+    [Theory]
+    [InlineData("(10/null)<0")]
+    [InlineData("(10/null)>0")]
+    public void CompareWithNullShouldReturnFalse(string expression)
+    {
+        var e = new Expression(expression, ExpressionOptions.AllowNullParameter);
+        e.Parameters["x"] = null;
+
+        Assert.False((bool)e.Evaluate());
+    }
 }


### PR DESCRIPTION
This PR fixes the bug with comparing null values, now it's match CLR logic.
Closes #402 