### PR TITLE
Do not treat integers as decimals when DecimalAsDefault specified

### DIFF
--- a/src/NCalc.Core/Parser/LogicalExpressionParser.cs
+++ b/src/NCalc.Core/Parser/LogicalExpressionParser.cs
@@ -430,6 +430,9 @@ public static class LogicalExpressionParser
         long? decimalPart = number.Item3;
         long? exponentPart = number.Item4;
 
+        if (decimalPart == null && exponentPart == null)
+            return new ValueExpression(integralValue);
+
         if (((LogicalExpressionParserContext)context).Options.HasFlag(ExpressionOptions.DecimalAsDefault))
         {
             decimal result1 = integralValue;
@@ -442,7 +445,9 @@ public static class LogicalExpressionParser
             }
 
             // exponent part?
-            if (exponentPart == null) return new ValueExpression(result1);
+            if (exponentPart == null)
+                return new ValueExpression(result1);
+
             var left = new BigDecimal(result1);
             var right = BigDecimal.Pow(10, exponentPart.Value);
 

--- a/test/NCalc.Tests/DecimalsTests.cs
+++ b/test/NCalc.Tests/DecimalsTests.cs
@@ -160,4 +160,16 @@ public class DecimalsTests
         Assert.Equal(0UL, new Expression("0b00001111 & 0b11110000").Evaluate());
         Assert.Equal(255UL, new Expression("0b00001111 | 0b11110000").Evaluate());
     }
+
+    [Theory]
+    [InlineData("1")]
+    [InlineData("1+2")]
+    [InlineData("4-3")]
+    [InlineData("1*2")]
+    public void ShouldNotTreatIntegersAsDecimals(string expr)
+    {
+        var expression = new Expression(expr, ExpressionOptions.DecimalAsDefault);
+        var res = expression.Evaluate();
+        Assert.Equal(typeof(int), res.GetType());
+    }
 }


### PR DESCRIPTION
This PR fixes an unintended breaking change when integers are treated as decimals when ExpressionOptions.DecimalAsDefault is used.

Closes #400