### PR TITLE
@WIP Compile vs CompileFast benchmarks

### DIFF
--- a/src/NCalc.Sync/Expression.Lambda.cs
+++ b/src/NCalc.Sync/Expression.Lambda.cs
@@ -1,4 +1,5 @@
-﻿using NCalc.Exceptions;
+﻿using System.Linq.Expressions;
+using NCalc.Exceptions;
 using NCalc.Visitors;
 using LinqExpression = System.Linq.Expressions.Expression;
 using LinqParameterExpression = System.Linq.Expressions.ParameterExpression;
@@ -46,6 +47,13 @@ public partial class Expression
     protected virtual LinqExpressionWithParameter ToLinqExpression<TContext, TResult>()
     {
         return ToLinqExpressionInternal<TContext, TResult>();
+    }
+
+    // todo: @wip added for the benchmark
+    public Expression<Func<TResult>> ToLambdaExpression<TResult>()
+    {
+        var body = ToLinqExpression<TResult>();
+        return LinqExpression.Lambda<Func<TResult>>(body);
     }
 
     public Func<TResult> ToLambda<TResult>()

--- a/test/NCalc.Benchmarks/EvaluateVsLambdaBenchmark.cs
+++ b/test/NCalc.Benchmarks/EvaluateVsLambdaBenchmark.cs
@@ -1,9 +1,29 @@
-﻿using BenchmarkDotNet.Attributes;
+﻿using System.Linq.Expressions;
+using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Order;
 using NCalc.Factories;
+using FastExpressionCompiler;
 
 namespace NCalc.Benchmarks;
 
+/*
+## Initial Results
+
+> Seems nothing to woкry about, but check the InvokeCompiledBenchmark
+
+BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.3775)
+Intel Core i9-8950HK CPU 2.90GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
+.NET SDK 9.0.203
+  [Host]     : .NET 8.0.15 (8.0.1525.16413), X64 RyuJIT AVX2
+  DefaultJob : .NET 8.0.15 (8.0.1525.16413), X64 RyuJIT AVX2
+
+
+| Method       | Mean      | Error     | StdDev    | Ratio | RatioSD | Rank | Allocated | Alloc Ratio |
+|------------- |----------:|----------:|----------:|------:|--------:|-----:|----------:|------------:|
+| Compiled     | 0.5119 ns | 0.0395 ns | 0.0660 ns |  1.02 |    0.19 |    1 |         - |          NA |
+| CompiledFast | 0.9849 ns | 0.0472 ns | 0.0562 ns |  1.96 |    0.28 |    2 |         - |          NA |
+
+*/
 [RankColumn]
 [CategoriesColumn]
 [MemoryDiagnoser]
@@ -11,10 +31,11 @@ namespace NCalc.Benchmarks;
 public class EvaluateVsLambdaBenchmark
 {
     private Expression Expression { get; set; }
-    private Func<bool> LambdaExpression { get; set; }
+    private Func<bool> LambdaCompiled { get; set; }
+    private Func<bool> LambdaCompiledFast { get; set; }
+    private Expression<Func<bool>> LambdaExpression { get; set; }
 
-    [GlobalSetup]
-    public void Setup()
+    public static Expression BuildNCalcExpression()
     {
         var logicalExpression = LogicalExpressionFactory.Create("(1 + a == 5 + b) == (42 == answer)");
         var expression = new Expression(logicalExpression, ExpressionOptions.NoCache)
@@ -26,26 +47,99 @@ public class EvaluateVsLambdaBenchmark
                 ["answer"] = 42
             }
         };
+        return expression;
+    }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var expression = BuildNCalcExpression();
 
         Expression = expression;
-        LambdaExpression = expression.ToLambda<bool>();
+        LambdaExpression = expression.ToLambdaExpression<bool>();
+
+        LambdaCompiled = LambdaExpression.Compile();
+        LambdaCompiledFast = LambdaExpression.CompileFast();
+    }
+
+    [Benchmark(Baseline = true)]
+    public object Compile()
+    {
+        return LambdaExpression.Compile();
     }
 
     [Benchmark]
+    public object CompileFast()
+    {
+        return LambdaExpression.CompileFast();
+    }
+
+    // [Benchmark]
     public bool Evaluate()
     {
         return (bool)Expression.Evaluate()!;
     }
 
-    [Benchmark]
-    public bool LambdaWithCompilation()
+    // [Benchmark]
+    public bool LambdaWithCompilationFast()
     {
         return Expression.ToLambda<bool>()();
     }
 
-    [Benchmark]
+    // [Benchmark]
     public bool LambdaWithoutCompilation()
     {
-        return LambdaExpression();
+        return LambdaCompiled();
+    }
+}
+
+/*
+## Initial Results
+
+Huh, 2x slower than compiled is bad. Will work from here.
+
+BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.3775)
+Intel Core i9-8950HK CPU 2.90GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
+.NET SDK 9.0.203
+  [Host]     : .NET 8.0.15 (8.0.1525.16413), X64 RyuJIT AVX2
+  DefaultJob : .NET 8.0.15 (8.0.1525.16413), X64 RyuJIT AVX2
+
+
+| Method       | Mean      | Error     | StdDev    | Ratio | RatioSD | Rank | Allocated | Alloc Ratio |
+|------------- |----------:|----------:|----------:|------:|--------:|-----:|----------:|------------:|
+| Compiled     | 0.5119 ns | 0.0395 ns | 0.0660 ns |  1.02 |    0.19 |    1 |         - |          NA |
+| CompiledFast | 0.9849 ns | 0.0472 ns | 0.0562 ns |  1.96 |    0.28 |    2 |         - |          NA |
+
+*/
+[RankColumn]
+[CategoriesColumn]
+[MemoryDiagnoser]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+public class InvokeCompiledBenchmark
+{
+    private Func<bool> LambdaCompiled;
+    private Func<bool> LambdaCompiledFast;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var nCalcExpression = EvaluateVsLambdaBenchmark.BuildNCalcExpression();
+
+        var lambdaExpression = nCalcExpression.ToLambdaExpression<bool>();
+
+        LambdaCompiled = lambdaExpression.Compile();
+        LambdaCompiledFast = lambdaExpression.CompileFast();
+    }
+
+    [Benchmark(Baseline = true)]
+    public bool Compiled()
+    {
+        return LambdaCompiled();
+    }
+
+    [Benchmark]
+    public bool CompiledFast()
+    {
+        return LambdaCompiledFast();
     }
 }

--- a/test/NCalc.Benchmarks/NCalc.Benchmarks.csproj
+++ b/test/NCalc.Benchmarks/NCalc.Benchmarks.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageReference Include="FastExpressionCompiler" Version="5.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/NCalc.Benchmarks/Program.cs
+++ b/test/NCalc.Benchmarks/Program.cs
@@ -1,6 +1,7 @@
 ﻿using BenchmarkDotNet.Running;
 using NCalc.Benchmarks;
 
-BenchmarkRunner.Run<LogicalExpressionFactoryBenchmark>(null, args);
-BenchmarkRunner.Run<SimpleEvaluationBenchmark>(null, args);
+// BenchmarkRunner.Run<LogicalExpressionFactoryBenchmark>(null, args);
+// BenchmarkRunner.Run<SimpleEvaluationBenchmark>(null, args);
 BenchmarkRunner.Run<EvaluateVsLambdaBenchmark>(null, args);
+BenchmarkRunner.Run<InvokeCompiledBenchmark>(null, args);


### PR DESCRIPTION
@Bykiev 

Initial results are here.

It is unexpected 2x slowness for the Invocation of compiled fast delegate.
Will look into.

```md
BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.3775)
Intel Core i9-8950HK CPU 2.90GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET SDK 9.0.203
  [Host]     : .NET 8.0.15 (8.0.1525.16413), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.15 (8.0.1525.16413), X64 RyuJIT AVX2


| Method       | Mean      | Error     | StdDev    | Ratio | RatioSD | Rank | Allocated | Alloc Ratio |
|------------- |----------:|----------:|----------:|------:|--------:|-----:|----------:|------------:|
| Compiled     | 0.5119 ns | 0.0395 ns | 0.0660 ns |  1.02 |    0.19 |    1 |         - |          NA |
| CompiledFast | 0.9849 ns | 0.0472 ns | 0.0562 ns |  1.96 |    0.28 |    2 |         - |          NA |

```