### PR TITLE
Refactor SerializationVisitor to remove ObjectPool dependency.

### DIFF
--- a/src/NCalc.Core/NCalc.Core.csproj
+++ b/src/NCalc.Core/NCalc.Core.csproj
@@ -8,7 +8,7 @@
         <AssemblyOriginatorKeyFile>../../NCalc.snk</AssemblyOriginatorKeyFile>
         <RootNamespace>NCalc</RootNamespace>
     </PropertyGroup>
-    
+
     <ItemGroup>
         <None Include="../../NCalc.png">
             <Pack>True</Pack>
@@ -16,24 +16,23 @@
         </None>
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
-        <PackageReference Include="System.Collections.Immutable" Version="9.0.4" />
+        <PackageReference Include="System.Collections.Immutable" Version="9.0.4"/>
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-      <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-        <PackageReference Include="System.ValueTuple" Version="4.6.1" />
-        <PackageReference Include="NETStandard.Library" Version="2.0.3" />
+        <PackageReference Include="Microsoft.CSharp" Version="4.7.0"/>
+        <PackageReference Include="System.ValueTuple" Version="4.6.1"/>
+        <PackageReference Include="NETStandard.Library" Version="2.0.3"/>
     </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" /></ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+        <PackageReference Include="Microsoft.CSharp" Version="4.7.0"/>
+    </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="ExtendedNumerics.BigDecimal" Version="3000.0.3.40" />
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.4" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.4" />
-        <PackageReference Include="Microsoft.Extensions.Logging.TraceSource" Version="9.0.4" />
-        <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="9.0.4" />
-        <PackageReference Include="Parlot" Version="1.3.5" />
+        <PackageReference Include="ExtendedNumerics.BigDecimal" Version="3000.0.3.40"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.4"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.TraceSource" Version="9.0.4"/>
+        <PackageReference Include="Parlot" Version="1.3.5"/>
     </ItemGroup>
 </Project>

--- a/src/NCalc.Core/Visitors/SerializationVisitor.cs
+++ b/src/NCalc.Core/Visitors/SerializationVisitor.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.ObjectPool;
-using NCalc.Domain;
+﻿using NCalc.Domain;
 using ValueType = NCalc.Domain.ValueType;
 
 namespace NCalc.Visitors;
@@ -9,13 +8,6 @@ namespace NCalc.Visitors;
 /// </summary>
 public class SerializationVisitor : ILogicalExpressionVisitor<string>
 {
-    private static readonly ObjectPool<StringBuilder> StringBuilderPool;
-
-    static SerializationVisitor()
-    {
-        StringBuilderPool = new DefaultObjectPoolProvider().CreateStringBuilderPool();
-    }
-
     private readonly NumberFormatInfo _numberFormatInfo = new()
     {
         NumberDecimalSeparator = "."
@@ -23,139 +15,73 @@ public class SerializationVisitor : ILogicalExpressionVisitor<string>
 
     public string Visit(TernaryExpression expression)
     {
-        var resultBuilder = StringBuilderPool.Get();
-
+        var resultBuilder = new StringBuilder();
         resultBuilder.Append(EncapsulateNoValue(expression.LeftExpression));
         resultBuilder.Append("? ");
         resultBuilder.Append(EncapsulateNoValue(expression.MiddleExpression));
         resultBuilder.Append(": ");
         resultBuilder.Append(EncapsulateNoValue(expression.RightExpression));
-
-        var result = resultBuilder.ToString();
-        StringBuilderPool.Return(resultBuilder);
-
-        return result;
+        return resultBuilder.ToString();
     }
 
     public string Visit(BinaryExpression expression)
     {
-        var resultBuilder = StringBuilderPool.Get();
+        var resultBuilder = new StringBuilder();
         resultBuilder.Append(EncapsulateNoValue(expression.LeftExpression));
 
-        switch (expression.Type)
+        resultBuilder.Append(expression.Type switch
         {
-            case BinaryExpressionType.And:
-                resultBuilder.Append("and ");
-                break;
-            case BinaryExpressionType.Or:
-                resultBuilder.Append("or ");
-                break;
-            case BinaryExpressionType.Div:
-                resultBuilder.Append("/ ");
-                break;
-            case BinaryExpressionType.Equal:
-                resultBuilder.Append("= ");
-                break;
-            case BinaryExpressionType.Greater:
-                resultBuilder.Append("> ");
-                break;
-            case BinaryExpressionType.GreaterOrEqual:
-                resultBuilder.Append(">= ");
-                break;
-            case BinaryExpressionType.Lesser:
-                resultBuilder.Append("< ");
-                break;
-            case BinaryExpressionType.LesserOrEqual:
-                resultBuilder.Append("<= ");
-                break;
-            case BinaryExpressionType.Minus:
-                resultBuilder.Append("- ");
-                break;
-            case BinaryExpressionType.Modulo:
-                resultBuilder.Append("% ");
-                break;
-            case BinaryExpressionType.NotEqual:
-                resultBuilder.Append("!= ");
-                break;
-            case BinaryExpressionType.Plus:
-                resultBuilder.Append("+ ");
-                break;
-            case BinaryExpressionType.Times:
-                resultBuilder.Append("* ");
-                break;
-            case BinaryExpressionType.BitwiseAnd:
-                resultBuilder.Append("& ");
-                break;
-            case BinaryExpressionType.BitwiseOr:
-                resultBuilder.Append("| ");
-                break;
-            case BinaryExpressionType.BitwiseXOr:
-                resultBuilder.Append("^ ");
-                break;
-            case BinaryExpressionType.LeftShift:
-                resultBuilder.Append("<< ");
-                break;
-            case BinaryExpressionType.RightShift:
-                resultBuilder.Append(">> ");
-                break;
-            case BinaryExpressionType.Exponentiation:
-                resultBuilder.Append("** ");
-                break;
-            case BinaryExpressionType.In:
-                resultBuilder.Append("in ");
-                break;
-            case BinaryExpressionType.NotIn:
-                resultBuilder.Append("not in ");
-                break;
-            case BinaryExpressionType.Like:
-                resultBuilder.Append("like ");
-                break;
-            case BinaryExpressionType.NotLike:
-                resultBuilder.Append("not like ");
-                break;
-            case BinaryExpressionType.Unknown:
-                resultBuilder.Append("unknown ");
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+            BinaryExpressionType.And => "and ",
+            BinaryExpressionType.Or => "or ",
+            BinaryExpressionType.Div => "/ ",
+            BinaryExpressionType.Equal => "= ",
+            BinaryExpressionType.Greater => "> ",
+            BinaryExpressionType.GreaterOrEqual => ">= ",
+            BinaryExpressionType.Lesser => "< ",
+            BinaryExpressionType.LesserOrEqual => "<= ",
+            BinaryExpressionType.Minus => "- ",
+            BinaryExpressionType.Modulo => "% ",
+            BinaryExpressionType.NotEqual => "!= ",
+            BinaryExpressionType.Plus => "+ ",
+            BinaryExpressionType.Times => "* ",
+            BinaryExpressionType.BitwiseAnd => "& ",
+            BinaryExpressionType.BitwiseOr => "| ",
+            BinaryExpressionType.BitwiseXOr => "^ ",
+            BinaryExpressionType.LeftShift => "<< ",
+            BinaryExpressionType.RightShift => ">> ",
+            BinaryExpressionType.Exponentiation => "** ",
+            BinaryExpressionType.In => "in ",
+            BinaryExpressionType.NotIn => "not in ",
+            BinaryExpressionType.Like => "like ",
+            BinaryExpressionType.NotLike => "not like ",
+            BinaryExpressionType.Unknown => "unknown ",
+            _ => throw new ArgumentOutOfRangeException()
+        });
 
         resultBuilder.Append(EncapsulateNoValue(expression.RightExpression));
-
-        var result = resultBuilder.ToString();
-        StringBuilderPool.Return(resultBuilder);
-
-        return result;
+        return resultBuilder.ToString();
     }
 
     public string Visit(UnaryExpression expression)
     {
-        var resultBuilder = StringBuilderPool.Get();
+        var resultBuilder = new StringBuilder();
 
-        switch (expression.Type)
+        resultBuilder.Append(expression.Type switch
         {
-            case UnaryExpressionType.Not:
-                resultBuilder.Append('!');
-                break;
-            case UnaryExpressionType.Negate:
-                resultBuilder.Append('-');
-                break;
-            case UnaryExpressionType.BitwiseNot:
-                resultBuilder.Append('~');
-                break;
-        }
+            UnaryExpressionType.Not => "!",
+            UnaryExpressionType.Negate => "-",
+            UnaryExpressionType.BitwiseNot => "~",
+            _ => string.Empty
+        });
 
         resultBuilder.Append(EncapsulateNoValue(expression.Expression));
 
-        var result = resultBuilder.ToString();
-        StringBuilderPool.Return(resultBuilder);
-
-        return result;
+        return resultBuilder.ToString();
     }
 
     public string Visit(ValueExpression expression)
     {
-        var resultBuilder = StringBuilderPool.Get();
+        var resultBuilder = new StringBuilder();
 
         switch (expression.Type)
         {
@@ -177,15 +103,12 @@ public class SerializationVisitor : ILogicalExpressionVisitor<string>
                 break;
         }
 
-        var result = resultBuilder.ToString();
-        StringBuilderPool.Return(resultBuilder);
-
-        return result;
+        return resultBuilder.ToString();
     }
 
     public string Visit(Function function)
     {
-        var resultBuilder = StringBuilderPool.Get();
+        var resultBuilder = new StringBuilder();
         resultBuilder.Append(function.Identifier.Name).Append('(');
 
         for (int i = 0; i < function.Parameters.Count; i++)
@@ -202,28 +125,17 @@ public class SerializationVisitor : ILogicalExpressionVisitor<string>
             resultBuilder.Remove(resultBuilder.Length - 1, 1);
 
         resultBuilder.Append(") ");
-
-        var result = resultBuilder.ToString();
-        StringBuilderPool.Return(resultBuilder);
-
-        return result;
+        return resultBuilder.ToString();
     }
 
     public string Visit(Identifier identifier)
     {
-        var resultBuilder = StringBuilderPool.Get();
-        resultBuilder.Append('[').Append(identifier.Name).Append("] ");
-
-        var result = resultBuilder.ToString();
-        StringBuilderPool.Return(resultBuilder);
-
-        return result;
+        return $"[{identifier.Name}]";
     }
 
     public string Visit(LogicalExpressionList list)
     {
-        var resultBuilder = StringBuilderPool.Get();
-        resultBuilder.Append('(');
+        var resultBuilder = new StringBuilder().Append('(');
         for (var i = 0; i < list.Count; i++)
         {
             resultBuilder.Append(list[i].Accept(this).TrimEnd());
@@ -233,33 +145,21 @@ public class SerializationVisitor : ILogicalExpressionVisitor<string>
             }
         }
         resultBuilder.Append(')');
-
-        var result = resultBuilder.ToString();
-        StringBuilderPool.Return(resultBuilder);
-
-        return result;
+        return resultBuilder.ToString();
     }
 
     protected virtual string EncapsulateNoValue(LogicalExpression expression)
     {
         if (expression is ValueExpression valueExpression)
-        {
             return valueExpression.Accept(this);
-        }
 
-        var resultBuilder = StringBuilderPool.Get();
-        resultBuilder.Append('(');
+        var resultBuilder = new StringBuilder().Append('(');
         resultBuilder.Append(expression.Accept(this));
 
-        // trim spaces before adding a closing paren
         while (resultBuilder[^1] == ' ')
-            resultBuilder.Remove(resultBuilder.Length - 1, 1);
+            resultBuilder.Length--;
 
         resultBuilder.Append(") ");
-
-        var result = resultBuilder.ToString();
-        StringBuilderPool.Return(resultBuilder);
-
-        return result;
+        return resultBuilder.ToString();
     }
 }

--- a/src/NCalc.DependencyInjection/NCalc.DependencyInjection.csproj
+++ b/src/NCalc.DependencyInjection/NCalc.DependencyInjection.csproj
@@ -8,10 +8,6 @@
         </Description>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
-    
-    <ItemGroup>
-        <None Include="README.md" Pack="true" PackagePath="" />
-    </ItemGroup>
 
     <ItemGroup>
         <None Include="../../NCalc.png">

--- a/src/Plugins/NCalc.MemoryCache/NCalc.MemoryCache.csproj
+++ b/src/Plugins/NCalc.MemoryCache/NCalc.MemoryCache.csproj
@@ -18,7 +18,6 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.4" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.4" />
     </ItemGroup>
 
 </Project>

--- a/src/Plugins/NCalc.MemoryCache/NCalc.MemoryCache.csproj
+++ b/src/Plugins/NCalc.MemoryCache/NCalc.MemoryCache.csproj
@@ -18,7 +18,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.4" />
-      <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.4" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.4" />
     </ItemGroup>
 
 </Project>

--- a/test/NCalc.Tests/NCalc.Tests.csproj
+++ b/test/NCalc.Tests/NCalc.Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="xunit.v3" Version="1.1.0" />
+    <PackageReference Include="xunit.v3" Version="2.0.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Replaced the usage of ObjectPool for StringBuilder instances with direct instantiation for simplicity and reduced complexity. 

I think the performance impact is not worth the complexity of the dependency and `SerializationVisitor` is not related to expression execution. I'm having issues at a project using .NET Framework 4.8 with WebForms, causing web.config `<runtime>` section .dll hell.