### PR TITLE
Update Parlot

### DIFF
--- a/src/NCalc.Core/NCalc.Core.csproj
+++ b/src/NCalc.Core/NCalc.Core.csproj
@@ -33,6 +33,6 @@
         <PackageReference Include="ExtendedNumerics.BigDecimal" Version="3000.0.4.132" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.5" />
         <PackageReference Include="Microsoft.Extensions.Logging.TraceSource" Version="9.0.5" />
-        <PackageReference Include="Parlot" Version="1.3.6" />
+        <PackageReference Include="Parlot" Version="1.4.0" />
     </ItemGroup>
 </Project>

--- a/test/NCalc.Tests/TestData/ValuesTestData.cs
+++ b/test/NCalc.Tests/TestData/ValuesTestData.cs
@@ -8,7 +8,7 @@ public class ValuesTestData : TheoryData<string, object>
         Add(".2", 0.2d);
         Add("123.456", 123.456d);
         Add("123.", 123d);
-        Add("123.E2", 12300d);
+        Add("123.0E2", 12300d);
         Add("true", true);
         Add("'true'", "true");
         Add("'azerty'", "azerty");


### PR DESCRIPTION
The new version causes a breaking change - 123.E2 is not a valid expression anymore, should be 123.0E2