### PR TITLE
Disable caching in benchmarks

### DIFF
--- a/test/NCalc.Benchmarks/LogicalExpressionFactoryBenchmark.cs
+++ b/test/NCalc.Benchmarks/LogicalExpressionFactoryBenchmark.cs
@@ -34,24 +34,24 @@ public class LogicalExpressionFactoryBenchmark
     [Benchmark]
     public LogicalExpression SimpleAntlrExpression()
     {
-        return AntlrFactory.Create(SimpleExpression);
+        return AntlrFactory.Create(SimpleExpression, ExpressionOptions.NoCache);
     }
 
     [Benchmark]
     public LogicalExpression SimpleParlotExpression()
     {
-        return ParlotFactory.Create(SimpleExpression);
+        return ParlotFactory.Create(SimpleExpression, ExpressionOptions.NoCache);
     }
 
     [Benchmark]
     public LogicalExpression AdvancedAntlrExpression()
     {
-        return AntlrFactory.Create(AdvancedExpression);
+        return AntlrFactory.Create(AdvancedExpression, ExpressionOptions.NoCache);
     }
 
     [Benchmark]
     public LogicalExpression AdvancedParlotExpression()
     {
-        return ParlotFactory.Create(AdvancedExpression);
+        return ParlotFactory.Create(AdvancedExpression, ExpressionOptions.NoCache);
     }
 }

--- a/test/NCalc.Benchmarks/NCalc.Benchmarks.csproj
+++ b/test/NCalc.Benchmarks/NCalc.Benchmarks.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.15.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/NCalc.Benchmarks/NCalcVsDataTableBenchmark.cs
+++ b/test/NCalc.Benchmarks/NCalcVsDataTableBenchmark.cs
@@ -20,7 +20,7 @@ public class NCalcVsDataTableBenchmark
     [GlobalSetup]
     public void Setup()
     {
-        Expression = new Expression(ExpressionString);
+        Expression = new Expression(ExpressionString, ExpressionOptions.NoCache);
         DataTable = new DataTable();
     }
 

--- a/test/NCalc.Benchmarks/SimpleEvaluationBenchmark.cs
+++ b/test/NCalc.Benchmarks/SimpleEvaluationBenchmark.cs
@@ -17,7 +17,7 @@ public class SimpleEvaluationBenchmark
     public void Setup()
     {
         var logicalExpression = LogicalExpressionFactory.Create("pi == 3.14 || 'Chers' == name");
-        var expression = new Expression(logicalExpression)
+        var expression = new Expression(logicalExpression, ExpressionOptions.NoCache)
         {
             Parameters =
             {


### PR DESCRIPTION
Disable caching in benchmarks to get a more accurate results