### PR TITLE
Parlot - use Parser.Parse instead of Parser.TryParse

### DIFF
--- a/src/NCalc.Core/Parser/LogicalExpressionParser.cs
+++ b/src/NCalc.Core/Parser/LogicalExpressionParser.cs
@@ -469,15 +469,21 @@ public static class LogicalExpressionParser
     {
         var parser = GetOrCreateExpressionParser(context.CultureInfo);
 
-        if (parser.TryParse(context, out var result, out var error))
+        try
+        {
+            var result = parser.Parse(context);
+            if (result == null)
+            {
+                string message = $"Error parsing the expression at position {context.Scanner.Cursor.Position}";
+                throw new NCalcParserException(message);
+            }
+
             return result;
-
-        string message;
-        if (error != null)
-            message = $"{error.Message} at position {error.Position}";
-        else
-            message = $"Error parsing the expression at position {context.Scanner.Cursor.Position}";
-
-        throw new NCalcParserException(message);
+        }
+        catch (ParseException ex)
+        {
+            string message = $"{ex.Message} at position {ex.Position}";
+            throw new NCalcParserException(message);
+        }
     }
 }


### PR DESCRIPTION
Improve Parlot parser performance by using Parser.Parse, instead of Parser.TryParse.

This PR is based on Parlot's benchmark:

BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.2314)
12th Gen Intel Core i7-1260P, 1 CPU, 16 logical and 12 physical cores
.NET SDK 9.0.100
  [Host]   : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2
  ShortRun : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2

Job=ShortRun  IterationCount=3  LaunchCount=1
WarmupCount=3

| Method              | Mean        | Error       | StdDev    | Ratio | Allocated | Alloc Ratio |
|-------------------- |------------:|------------:|----------:|------:|----------:|------------:|
| ParlotRawSmall      |    201.4 ns |    53.24 ns |   2.92 ns |  0.49 |     304 B |        0.44 |
| ParlotFluentSmall   |    460.2 ns |   206.97 ns |  11.34 ns |  1.13 |     688 B |        1.00 |

2x time difference, it's seems the overhead is caused by `out` params and try/catch block and JITting is not applied.
But our benchmarks are confusing:


BenchmarkDotNet v0.15.1, Linux Ubuntu 24.04.2 LTS (Noble Numbat)
AMD EPYC 7763, 1 CPU, 4 logical and 2 physical cores
.NET SDK 9.0.302
  [Host]     : .NET 8.0.18 (8.0.1825.31117), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.18 (8.0.1825.31117), X64 RyuJIT AVX2

Before:
| Method                   | Mean      | Error     | StdDev    | Rank | Gen0   | Gen1   | Allocated |
|------------------------- |----------:|----------:|----------:|-----:|-------:|-------:|----------:|
| SimpleParlotExpression   |  6.596 us | 0.0244 us | 0.0217 us |    1 | 0.0610 |      - |   1.05 KB |
| AdvancedParlotExpression | 16.728 us | 0.0797 us | 0.0707 us |    3 | 0.1526 |      - |   2.98 KB |
| LambdaWithoutCompilation |   0.3696 ns | 0.0062 ns | 0.0055 ns |    1 |      - |         - |
| LambdaWithCompilation    | 702.3531 ns | 6.1587 ns | 5.7608 ns |    2 | 0.0248 |     424 B |
| Evaluate                 | 743.7670 ns | 7.3436 ns | 6.8692 ns |    3 | 0.1059 |    1776 B |

After:
| Method                   | Mean      | Error     | StdDev    | Rank | Gen0   | Gen1   | Allocated |
|------------------------- |----------:|----------:|----------:|-----:|-------:|-------:|----------:|
| SimpleParlotExpression   |  6.417 us | 0.0178 us | 0.0158 us |    1 | 0.0610 |      - |   1.05 KB |
| AdvancedParlotExpression | 16.536 us | 0.0220 us | 0.0172 us |    3 | 0.1526 |      - |   2.98 KB |
| LambdaWithoutCompilation |   0.3690 ns |  0.0057 ns | 0.0048 ns |    1 |      - |         - |
| LambdaWithCompilation    | 722.0903 ns |  3.9702 ns | 3.5195 ns |    2 | 0.0248 |     424 B |
| Evaluate                 | 767.6887 ns | 10.9282 ns | 9.1255 ns |    3 | 0.1059 |    1776 B |

So, some benchmarks shows improved result with Parser.Parse method, but some of them degraded. Seems this PR doesn't make any sense... 