### PR TITLE
Improve MathHelper performance

### DIFF
--- a/src/NCalc.Core/Helpers/MathHelper.cs
+++ b/src/NCalc.Core/Helpers/MathHelper.cs
@@ -413,10 +413,10 @@ public static class MathHelper
     {
         return value switch
         {
-            char when options is { DecimalAsDefault: true, AllowCharValues: false } => decimal.Parse(value.ToString()!, options.CultureInfo),
-            string when options is { DecimalAsDefault: true } => decimal.Parse(value.ToString()!, options.CultureInfo),
-            char when options is { AllowCharValues: false } => double.Parse(value.ToString()!, options.CultureInfo),
-            string => double.Parse(value.ToString()!, options.CultureInfo),
+            char ch when options is { DecimalAsDefault: true, AllowCharValues: false } => decimal.Parse(ch.ToString(), options.CultureInfo),
+            string s when options is { DecimalAsDefault: true } => decimal.Parse(s, options.CultureInfo),
+            char ch when options is { AllowCharValues: false } => double.Parse(ch.ToString(), options.CultureInfo),
+            string s => double.Parse(s, options.CultureInfo),
             bool boolean when options.AllowBooleanCalculation => boolean ? 1 : 0,
             _ => value
         };
@@ -427,7 +427,7 @@ public static class MathHelper
         return value switch
         {
             double @double => @double,
-            char => Convert.ToDouble(value.ToString(), options.CultureInfo),
+            char ch => Convert.ToDouble(ch.ToString(), options.CultureInfo),
             _ => Convert.ToDouble(value, options.CultureInfo)
         };
     }
@@ -437,7 +437,7 @@ public static class MathHelper
         return value switch
         {
             decimal @decimal => @decimal,
-            char => Convert.ToDecimal(value.ToString(), options.CultureInfo),
+            char ch => Convert.ToDecimal(ch.ToString(), options.CultureInfo),
             _ => Convert.ToDecimal(value, options.CultureInfo)
         };
     }
@@ -447,7 +447,7 @@ public static class MathHelper
         return value switch
         {
             int i => i,
-            char => Convert.ToInt32(value.ToString(), options.CultureInfo),
+            char ch => Convert.ToInt32(ch.ToString(), options.CultureInfo),
             _ => Convert.ToInt32(value, options.CultureInfo)
         };
     }


### PR DESCRIPTION
Improve MathHelper performance by avoiding boxing. 

BenchmarkDotNet=v0.13.12, OS=Windows 11 (10.0.22631.3527)
Intel Core i7-10700K (8C/16T), 1 CPU, 3.80GHz, 32GB RAM
.NET SDK=8.0.100
  [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2

| Method                      | Mean     | Error     | StdDev  | Ratio | Gen0   | Allocated |
|----------------------------|---------:|----------:|--------:|------:|-------:|----------:|
| ConvertIfNeededString_After | 24.80 ns | 0.110 ns | 0.103 ns | 1.00  | 0.0076 |      48 B |
| ConvertIfNeededString_Before | 34.60 ns | 0.150 ns | 0.140 ns | 1.40  | 0.0153 |      96 B |
| ConvertIfNeededChar_After | 29.90 ns | 0.120 ns | 0.112 ns | 1.00  | 0.0076 |      48 B | 
| ConvertIfNeededChar_Before  | 68.40 ns | 0.340 ns | 0.318 ns | 2.29  | 0.0305 |     192 B |
