### PR TITLE
Remove obsolete Like(string value, string pattern, ExpressionContextB…

### DIFF
--- a/src/NCalc.Core/Helpers/EvaluationHelper.cs
+++ b/src/NCalc.Core/Helpers/EvaluationHelper.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using NCalc.Domain;
 using NCalc.Exceptions;


### PR DESCRIPTION
…ase context) method