### PR TITLE
Disable parser loop detection

### DIFF
--- a/src/NCalc.Core/Parser/LogicalExpressionParserContext.cs
+++ b/src/NCalc.Core/Parser/LogicalExpressionParserContext.cs
@@ -4,12 +4,13 @@ using Parlot.Fluent;
 namespace NCalc.Parser;
 
 public sealed class LogicalExpressionParserContext(string text, ExpressionOptions options, CancellationToken ct = default)
-    : ParseContext(new Scanner(text), ct)
+    : ParseContext(new Scanner(text), false, true, ct)
 {
     /// <summary>
     /// Parser options containing culture info and argument separator settings.
     /// </summary>
     public LogicalExpressionParserOptions ParserOptions { get; init; } = LogicalExpressionParserOptions.Default;
+
     public ExpressionOptions Options { get; } = options;
 
     public CultureInfo CultureInfo { get; } = CultureInfo.CurrentCulture;


### PR DESCRIPTION
As the parser is fully under our control infinite circle on parser level is impossible. Disabling this feature will improve the overall performance