### PR TITLE
Support for multiple argument separators in expression

### DIFF
--- a/docs/articles/functions.md
+++ b/docs/articles/functions.md
@@ -36,7 +36,7 @@ It also includes other general purpose ones.
 | if	    | Returns a value based on a condition.	                                                            | if(3 % 2 = 1, 'value is true', 'value is false')	 | 'value is true'                                                                |
 | ifs    | Returns a value based on evaluating a number of conditions, returning a default if none are true. | ifs(foo > 50, "bar", foo > 75, "baz", "quux")     | if foo is between 50 and 75 "bar", foo greater than 75 "baz", otherwise "quux" |  
 
-You can use comma (,) or semicolon (;) as argument separator.
+By default, the comma is used as argument separator, but you can change it using <xref:NCalc.Parser.ArgumentSeparator>. You can specify multiple separators.
 
 If <xref:NCalc.ExpressionOptions.DecimalAsDefault> is used all functions will cast the arguments to <xref:System.Decimal>.
 

--- a/src/NCalc.Core/Parser/ArgumentSeparator.cs
+++ b/src/NCalc.Core/Parser/ArgumentSeparator.cs
@@ -4,15 +4,21 @@ namespace NCalc.Parser;
 /// Defines the available argument separator options for function arguments.
 /// Each option specifies which character should be used to separate arguments in function calls.
 /// </summary>
+[Flags]
 public enum ArgumentSeparator
 {
+    /// <summary>
+    /// Default value, uses comma separator
+    /// </summary>
+    Default = 0,
+
     /// <summary>
     /// Uses semicolon (;) as the argument separator.
     /// This is commonly used in European locales where comma is used as decimal separator.
     /// Example: Max(1; 2; 3)
     /// </summary>
     /// <value>Character: ;</value>
-    Semicolon = 0,
+    Semicolon = 1,
 
     /// <summary>
     /// Uses colon (:) as the argument separator.
@@ -20,7 +26,7 @@ public enum ArgumentSeparator
     /// Example: Max(1:2:3)
     /// </summary>
     /// <value>Character: :</value>
-    Colon = 1,
+    Colon = 2,
 
     /// <summary>
     /// Uses comma (,) as the argument separator.
@@ -28,5 +34,5 @@ public enum ArgumentSeparator
     /// Example: Max(1, 2, 3)
     /// </summary>
     /// <value>Character: ,</value>
-    Comma = 2
+    Comma = 4
 }

--- a/src/NCalc.Core/Parser/LogicalExpressionParser.cs
+++ b/src/NCalc.Core/Parser/LogicalExpressionParser.cs
@@ -38,16 +38,40 @@ public static class LogicalExpressionParser
     /// <param name="separator">The ArgumentSeparator enum value.</param>
     /// <returns>The character representation of the separator.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when the separator value is not a valid ArgumentSeparator enum value.</exception>
-    private static char GetSeparatorChar(ArgumentSeparator separator)
+    private static char[] GetSeparatorChars(ArgumentSeparator separator)
     {
-        return separator switch
+        var separators = new List<char>();
+
+        if (separator == ArgumentSeparator.Default)
         {
-            ArgumentSeparator.Semicolon => ';',
-            ArgumentSeparator.Colon => ':',
-            ArgumentSeparator.Comma => ',',
-            _ => throw new ArgumentOutOfRangeException(nameof(separator), separator,
-                $"Unhandled ArgumentSeparator value: {separator}")
-        };
+            separators.Add(',');
+        }
+        else
+        {
+            if (separator.HasFlag(ArgumentSeparator.Semicolon))
+                separators.Add(';');
+
+            if (separator.HasFlag(ArgumentSeparator.Comma))
+                separators.Add(',');
+
+            if (separator.HasFlag(ArgumentSeparator.Colon))
+                separators.Add(':');
+        }
+
+        return separators.ToArray();
+    }
+
+    private static Parser<char> CreateSeparatorParser(char[] argumentSeparator)
+    {
+        var parser = Terms.Char(argumentSeparator[0]);
+
+        if (argumentSeparator.Length > 1)
+        {
+            for (int i = 1; i < argumentSeparator.Length; i++)
+                parser = parser.Or(Terms.Char(argumentSeparator[i]));
+        }
+
+        return parser;
     }
 
     /// <summary>
@@ -57,10 +81,10 @@ public static class LogicalExpressionParser
     /// <returns>A new parser configured with the specified options.</returns>
     private static Parser<LogicalExpression> CreateExpressionParser(LogicalExpressionParserOptions options)
     {
-        return CreateExpressionParser(options.CultureInfo, GetSeparatorChar(options.ArgumentSeparator));
+        return CreateExpressionParser(options.CultureInfo, GetSeparatorChars(options.ArgumentSeparator));
     }
 
-    private static Parser<LogicalExpression> CreateExpressionParser(CultureInfo cultureInfo, char argumentSeparator)
+    private static Parser<LogicalExpression> CreateExpressionParser(CultureInfo cultureInfo, char[] argumentSeparator)
     {
         /*
          * Grammar:
@@ -151,7 +175,7 @@ public static class LogicalExpressionParser
             return doubleNumber;
         });
 
-        var argumentSeparatorTerm = Terms.Char(argumentSeparator);
+        var argumentSeparatorTerm = CreateSeparatorParser(argumentSeparator);
         var divided = Terms.Text("/");
         var times = Terms.Text("*");
         var modulo = Terms.Text("%");

--- a/test/NCalc.Tests/ArgumentSeparatorTests.cs
+++ b/test/NCalc.Tests/ArgumentSeparatorTests.cs
@@ -279,4 +279,37 @@ public class ArgumentSeparatorTests
         Assert.Equal(5.0, commaValue);
         Assert.Equal(5.0, semicolonValue);
     }
+
+    [Fact]
+    public void Should_Support_Multiple_Separators_In_One_Parser()
+    {
+        var argumentSeparators = ArgumentSeparator.Comma | ArgumentSeparator.Semicolon;
+         
+        // Arrange
+        var argumentOptions = LogicalExpressionParserOptions.WithArgumentSeparator(argumentSeparators);
+
+        var commaExpression = "Max(1, 2)";
+        var semicolonExpression = "Max(3; 4)";
+
+        var commaContext = new LogicalExpressionParserContext(commaExpression, ExpressionOptions.None)
+        {
+            ParserOptions = argumentOptions
+        };
+
+        var semicolonContext = new LogicalExpressionParserContext(semicolonExpression, ExpressionOptions.None)
+        {
+            ParserOptions = argumentOptions
+        };
+
+        // Act
+        var commaResult = LogicalExpressionParser.Parse(commaContext);
+        var semicolonResult = LogicalExpressionParser.Parse(semicolonContext);
+
+        var commaValue = new Expression(commaResult).Evaluate(TestContext.Current.CancellationToken);
+        var semicolonValue = new Expression(semicolonResult).Evaluate(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(2, commaValue);
+        Assert.Equal(4, semicolonValue);
+    }
 }


### PR DESCRIPTION
Added suppport for multiple argument separators in expression for backward compatibility. The breaking change was introduced in #467

This is a sort of breaking change too.