### PR TITLE
Improve default expression cache

### DIFF
--- a/docs/articles/extensibility/plugins/memory_cache.md
+++ b/docs/articles/extensibility/plugins/memory_cache.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-If you want to use [IMemoryCache](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.caching.memory.imemorycache) to cache the parsing of expressions, you can use this plugin. The advantage of this plugin is that you can set a custom cache expiration.
+If you want to use [IMemoryCache](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.caching.memory.imemorycache) to cache the parsing of expressions, you can use this plugin. This is the better option when you want explicit cache expiration, eviction policy control, or a cache that is managed by the application's `IMemoryCache` infrastructure instead of the built-in default cache.
 
 ## Installation and Usage
 

--- a/docs/articles/runtime/caching.md
+++ b/docs/articles/runtime/caching.md
@@ -1,20 +1,35 @@
 ﻿## Caching
 
-When <xref:NCalc.Expression.Evaluate> is called on an expression, it is parsed once. If the same expression is reused the parse is not executed again. Thus, you can reuse <xref:NCalc.Expression>  instances by changing the parameters, and you will gain in performance because only the traversal of the expression tree will be done.
+When <xref:NCalc.Expression.Evaluate> is called on an expression, it is parsed once. If the same expression is reused, parsing is skipped and only the expression tree is evaluated again.
 
-Moreover, each parsed expression is cached internally, which means you don't even have to care about reusing an <xref:NCalc.Expression> instance, the framework will do it for you.
-The cache is automatically cleaned like the GC does when an Expression is no more used, or memory is needed (i.e. using [WeakReference<LogicalExpression>](https://learn.microsoft.com/en-us/dotnet/api/system.weakreference-1?view=net-8.0)).
+Each parsed expression is cached internally, which means you do not need to manually reuse an <xref:NCalc.Expression> instance for the parser cache to help.
 
-You can disable this behavior at the framework level by adding <xref:NCalc.ExpressionOptions.NoCache> at your [global expression context](../evaluation/expression_context.md).
+The default cache now keeps strong references and evicts the least recently used entries when it reaches its capacity. This is more predictable than a weak-reference cache and avoids scanning the whole dictionary on every insert.
 
-```c#
+You can disable caching at the framework level by adding <xref:NCalc.ExpressionOptions.NoCache> at your [global expression context](../evaluation/expression_context.md).
+
+```csharp
 MyContext.Value.Options = ExpressionOptions.NoCache;
 ```
 
-You can also tell a specific <xref:NCalc.Expression> instance not to be taken from the cache.
+You can also tell a specific <xref:NCalc.Expression> instance not to use the cache.
 
-```c#
+```csharp
 var expression = new Expression("1 + 1", ExpressionOptions.NoCache);
 ```
 
+## Default cache size
+
+The default cache size is `128` entries.
+
+If you are on modern .NET runtimes (.NET 8+) you can override it before the first expression is parsed by setting an `AppContext` value:
+
+```csharp
+AppContext.SetData("NCalc.LogicalExpressionCache.DefaultCapacity", "256");
+```
+
+The value must be a positive integer string. Set it during application startup so the default singleton cache picks it up before first use.
+
 You can customize the cache implementation using [Dependency Injection](../extensibility/dependency_injection.md).
+
+If you need expiration control or want the cache to be governed by `IMemoryCache`, use the [Memory Cache plugin](../extensibility/plugins/memory_cache.md) instead of the built-in cache.

--- a/src/NCalc.Core/Cache/LogicalExpressionCache.cs
+++ b/src/NCalc.Core/Cache/LogicalExpressionCache.cs
@@ -4,28 +4,73 @@ using NCalc.Logging;
 
 namespace NCalc.Cache;
 
-public sealed class LogicalExpressionCache(ILogger<LogicalExpressionCache>? logger = null) : ILogicalExpressionCache
+public sealed class LogicalExpressionCache : ILogicalExpressionCache
 {
-    private readonly ConcurrentDictionary<string, WeakReference<LogicalExpression>> _compiledExpressions = new();
-    private readonly ILogger<LogicalExpressionCache> _logger = logger ?? NullLogger<LogicalExpressionCache>.Instance;
+    private const string DefaultCapacitySwitchName = "NCalc.LogicalExpressionCache.DefaultCapacity";
+    private const int DefaultCapacity = 128;
+
+    private readonly Dictionary<string, LinkedListNode<CacheEntry>> _compiledExpressions = new(StringComparer.Ordinal);
+    private readonly LinkedList<CacheEntry> _lru = [];
+    #if NET10_0_OR_GREATER
+    private readonly Lock _lock = new();
+    #else
+    private readonly object _lock = new();
+    #endif
+    private readonly ILogger<LogicalExpressionCache> _logger;
+    private readonly int _capacity;
 
     private static readonly LogicalExpressionCache Instance;
 
     static LogicalExpressionCache()
     {
-        Instance = new LogicalExpressionCache(NullLoggerFactory.Instance.CreateLogger<LogicalExpressionCache>());
+        Instance = new LogicalExpressionCache(NullLoggerFactory.Instance.CreateLogger<LogicalExpressionCache>(), GetDefaultCapacity());
+    }
+
+    public LogicalExpressionCache(ILogger<LogicalExpressionCache>? logger = null)
+    {
+        _capacity = GetDefaultCapacity();
+        _logger = logger ?? NullLogger<LogicalExpressionCache>.Instance;
+    }
+
+    internal LogicalExpressionCache(ILogger<LogicalExpressionCache>? logger, int capacity)
+    {
+        _capacity = capacity > 0 ? capacity : throw new ArgumentOutOfRangeException(nameof(capacity));
+        _logger = logger ?? NullLogger<LogicalExpressionCache>.Instance;
+    }
+
+    private static int GetDefaultCapacity()
+    {
+#if NET
+        var configuredCapacityValue = AppContext.GetData(DefaultCapacitySwitchName) as string;
+#else
+        const string? configuredCapacityValue = null;
+#endif
+        if (string.IsNullOrWhiteSpace(configuredCapacityValue))
+            return DefaultCapacity;
+
+        return int.TryParse(configuredCapacityValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var configuredCapacity) &&
+               configuredCapacity > 0
+            ? configuredCapacity
+            : throw new InvalidOperationException(
+                $"The AppContext switch '{DefaultCapacitySwitchName}' must contain a positive integer value.");
     }
 
     public static LogicalExpressionCache GetInstance() => Instance;
 
     public bool TryGetValue(string expression, out LogicalExpression? logicalExpression)
     {
-        logicalExpression = null;
+        lock (_lock)
+        {
+            if (!_compiledExpressions.TryGetValue(expression, out var node))
+            {
+                logicalExpression = null;
+                return false;
+            }
 
-        if (!_compiledExpressions.TryGetValue(expression, out var wr))
-            return false;
-        if (!wr.TryGetTarget(out logicalExpression))
-            return false;
+            _lru.Remove(node);
+            _lru.AddFirst(node);
+            logicalExpression = node.Value.LogicalExpression;
+        }
 
         _logger.LogRetrievedFromCache(expression);
 
@@ -34,22 +79,35 @@ public sealed class LogicalExpressionCache(ILogger<LogicalExpressionCache>? logg
 
     public void Set(string expression, LogicalExpression logicalExpression)
     {
-        _compiledExpressions[expression] = new WeakReference<LogicalExpression>(logicalExpression);
-        ClearCache();
+        lock (_lock)
+        {
+            if (_compiledExpressions.TryGetValue(expression, out var existingNode))
+            {
+                _lru.Remove(existingNode);
+                _compiledExpressions.Remove(expression);
+            }
+
+            var node = new LinkedListNode<CacheEntry>(new CacheEntry(expression, logicalExpression));
+            _lru.AddFirst(node);
+            _compiledExpressions[expression] = node;
+
+            if (_compiledExpressions.Count > _capacity)
+                RemoveLeastRecentlyUsed();
+        }
+
         _logger.LogAddedToCache(expression);
     }
 
-    private void ClearCache()
+    private void RemoveLeastRecentlyUsed()
     {
-        foreach (var kvp in _compiledExpressions)
-        {
-            if (kvp.Value.TryGetTarget(out _))
-                continue;
+        var node = _lru.Last;
+        if (node is null)
+            return;
 
-            if (_compiledExpressions.TryRemove(kvp.Key, out _))
-            {
-                _logger.LogRemovedFromCache(kvp.Key);
-            }
-        }
+        _lru.RemoveLast();
+        _compiledExpressions.Remove(node.Value.Expression);
+        _logger.LogRemovedFromCache(node.Value.Expression);
     }
+
+    private sealed record CacheEntry(string Expression, LogicalExpression LogicalExpression);
 }

--- a/test/NCalc.Tests/LogicalExpressionCacheTests.cs
+++ b/test/NCalc.Tests/LogicalExpressionCacheTests.cs
@@ -1,0 +1,66 @@
+﻿using System.Reflection;
+using NCalc.Cache;
+using NCalc.Factories;
+
+namespace NCalc.Tests;
+
+[Property("Category", "Cache")]
+public class LogicalExpressionCacheTests
+{
+    [Test]
+    public async Task Should_ReturnCachedExpression()
+    {
+        var cache = new LogicalExpressionCache();
+        var expression = LogicalExpressionFactory.Create("1 + 1");
+
+        cache.Set("1 + 1", expression);
+
+        await Assert.That(cache.TryGetValue("1 + 1", out var cachedExpression)).IsTrue();
+        await Assert.That(cachedExpression).IsSameReferenceAs(expression);
+    }
+
+    [Test]
+    public async Task Should_EvictLeastRecentlyUsedExpression()
+    {
+        var cache = new LogicalExpressionCache();
+        const int capacity = 128;
+
+        for (var i = 0; i < capacity; i++)
+        {
+            var expressionText = $"value = {i}";
+            cache.Set(expressionText, LogicalExpressionFactory.Create(expressionText));
+        }
+
+        await Assert.That(cache.TryGetValue("value = 0", out _)).IsTrue();
+
+        cache.Set("value = 128", LogicalExpressionFactory.Create("value = 128"));
+
+        await Assert.That(cache.TryGetValue("value = 0", out _)).IsTrue();
+        await Assert.That(cache.TryGetValue("value = 1", out _)).IsFalse();
+        await Assert.That(cache.TryGetValue("value = 128", out _)).IsTrue();
+    }
+
+    [Test]
+    public async Task Should_ReadDefaultCapacityFromAppContext()
+    {
+        const string key = "NCalc.LogicalExpressionCache.DefaultCapacity";
+        const string value = "7";
+
+        var previousValue = AppContext.GetData(key);
+
+        try
+        {
+            AppContext.SetData(key, value);
+
+            var cache = new LogicalExpressionCache();
+            var capacityField = typeof(LogicalExpressionCache).GetField("_capacity", BindingFlags.Instance | BindingFlags.NonPublic);
+
+            await Assert.That(capacityField).IsNotNull();
+            await Assert.That(capacityField!.GetValue(cache)).IsEqualTo(7);
+        }
+        finally
+        {
+            AppContext.SetData(key, previousValue);
+        }
+    }
+}


### PR DESCRIPTION
This PR replaces the default weak-reference expression cache with a bounded strong-reference LRU cache. The previous implementation could drop entries unpredictably under GC
  pressure and scanned the full dictionary on every insert to remove dead references.