### PR TITLE
Rename `CancellationToken` parameters from ct to cancellationToken to align with Microsoft naming conventions.

### DIFF
--- a/src/NCalc.Core/Expression.cs
+++ b/src/NCalc.Core/Expression.cs
@@ -193,9 +193,9 @@ public class Expression
     /// </summary>
     /// <returns>The result of the evaluation.</returns>
     /// <exception cref="NCalcException">Thrown when there is an error in the expression.</exception>
-    public object? Evaluate(CancellationToken ct = default)
+    public object? Evaluate(CancellationToken cancellationToken = default)
     {
-        var valueTask = EvaluateAsync(ct);
+        var valueTask = EvaluateAsync(cancellationToken);
 
         if (valueTask.IsCompletedSuccessfully)
             return valueTask.Result;
@@ -206,12 +206,12 @@ public class Expression
     /// <summary>
     /// Asynchronously evaluates the logical expression.
     /// </summary>
-    /// <param name="ct">Cancellation token</param>
+    /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The result of the evaluation.</returns>
     /// <exception cref="NCalcException">Thrown when there is an error in the expression.</exception>
-    public async ValueTask<object?> EvaluateAsync(CancellationToken ct = default)
+    public async ValueTask<object?> EvaluateAsync(CancellationToken cancellationToken = default)
     {
-        LogicalExpression ??= GetLogicalExpression(ct);
+        LogicalExpression ??= GetLogicalExpression(cancellationToken);
 
         if (Error is not null)
             throw Error;
@@ -220,14 +220,14 @@ public class Expression
         {
             // If array evaluation, execute the same expression multiple times
             if (Options.HasFlag(ExpressionOptions.IterateParameters))
-                return await IterateParametersAsync(ct).ConfigureAwait(false);
+                return await IterateParametersAsync(cancellationToken).ConfigureAwait(false);
 
             var evaluationVisitor = EvaluationVisitorFactory.Create(Context);
 
             if (LogicalExpression is null)
                 return null;
 
-            return await LogicalExpression.Accept(evaluationVisitor, ct).ConfigureAwait(false);
+            return await LogicalExpression.Accept(evaluationVisitor, cancellationToken).ConfigureAwait(false);
         }
         catch (InvalidCastException exception)
         {
@@ -235,7 +235,7 @@ public class Expression
         }
     }
 
-    private async ValueTask<object?> IterateParametersAsync(CancellationToken ct)
+    private async ValueTask<object?> IterateParametersAsync(CancellationToken cancellationToken)
     {
         var parameterEnumerators = ParametersHelper.GetEnumerators(Parameters, out var size);
 
@@ -245,7 +245,7 @@ public class Expression
             return null;
 
         if (size == null)
-            return await LogicalExpression.Accept(evaluationVisitor, ct);
+            return await LogicalExpression.Accept(evaluationVisitor, cancellationToken);
 
         var results = new List<object?>();
 
@@ -257,7 +257,7 @@ public class Expression
                 Parameters[kvp.Key] = kvp.Value.Current;
             }
 
-            results.Add(await LogicalExpression.Accept(evaluationVisitor, ct));
+            results.Add(await LogicalExpression.Accept(evaluationVisitor, cancellationToken));
         }
 
         return results;
@@ -266,38 +266,38 @@ public class Expression
     /// <summary>
     /// Returns a list with all parameter names from the expression.
     /// </summary>
-    /// <param name="ct">Cancellation token</param>
-    public List<string> GetParameterNames(CancellationToken ct = default)
+    /// <param name="cancellationToken">Cancellation token</param>
+    public List<string> GetParameterNames(CancellationToken cancellationToken = default)
     {
         var parameterExtractionVisitor = new ParameterExtractionVisitor();
-        LogicalExpression ??= LogicalExpressionFactory.Create(ExpressionString!, CultureInfo, Context.Options, ct);
-        return LogicalExpression.Accept(parameterExtractionVisitor, ct);
+        LogicalExpression ??= LogicalExpressionFactory.Create(ExpressionString!, CultureInfo, Context.Options, cancellationToken);
+        return LogicalExpression.Accept(parameterExtractionVisitor, cancellationToken);
     }
 
     /// <summary>
     /// Returns a list with all function names from the expression.
     /// </summary>
-    /// <param name="ct">Cancellation token</param>
-    public List<string> GetFunctionNames(CancellationToken ct = default)
+    /// <param name="cancellationToken">Cancellation token</param>
+    public List<string> GetFunctionNames(CancellationToken cancellationToken = default)
     {
         var functionExtractionVisitor = new FunctionExtractionVisitor();
-        LogicalExpression ??= LogicalExpressionFactory.Create(ExpressionString!, CultureInfo, Context.Options, ct);
-        return LogicalExpression.Accept(functionExtractionVisitor, ct);
+        LogicalExpression ??= LogicalExpressionFactory.Create(ExpressionString!, CultureInfo, Context.Options, cancellationToken);
+        return LogicalExpression.Accept(functionExtractionVisitor, cancellationToken);
     }
 
     /// <summary>
     /// Create the LogicalExpression in order to check syntax errors.
     /// If errors are detected, the Error property contains the exception.
     /// </summary>
-    /// <param name="ct">Cancellation token</param>
+    /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>True if the expression syntax is correct, otherwise False.</returns>
     [MemberNotNullWhen(true, nameof(Error))]
-    public bool HasErrors(CancellationToken ct = default)
+    public bool HasErrors(CancellationToken cancellationToken = default)
     {
         try
         {
             Error = null;
-            LogicalExpression = LogicalExpressionFactory.Create(ExpressionString!, CultureInfo, Context.Options, ct);
+            LogicalExpression = LogicalExpressionFactory.Create(ExpressionString!, CultureInfo, Context.Options, cancellationToken);
 
             // In case HasErrors() is called multiple times for the same expression
             return LogicalExpression != null && Error != null;
@@ -309,7 +309,7 @@ public class Expression
         }
     }
 
-    public LogicalExpression? GetLogicalExpression(CancellationToken ct = default)
+    public LogicalExpression? GetLogicalExpression(CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrEmpty(ExpressionString))
         {
@@ -332,7 +332,7 @@ public class Expression
         {
             Error = null;
 
-            logicalExpression = LogicalExpressionFactory.Create(ExpressionString!, CultureInfo, Context.Options, ct);
+            logicalExpression = LogicalExpressionFactory.Create(ExpressionString!, CultureInfo, Context.Options, cancellationToken);
             if (isCacheEnabled)
                 LogicalExpressionCache.Set(ExpressionString!, logicalExpression);
         }
@@ -344,9 +344,9 @@ public class Expression
         return logicalExpression;
     }
 
-    public string ToExpressionString(bool evaluateParameters = false, CancellationToken ct = default)
+    public string ToExpressionString(bool evaluateParameters = false, CancellationToken cancellationToken = default)
     {
-        var logicalExpression = GetLogicalExpression(ct);
+        var logicalExpression = GetLogicalExpression(cancellationToken);
 
         if (Error is not null)
             throw Error;
@@ -355,8 +355,8 @@ public class Expression
             return string.Empty;
 
         if (!evaluateParameters)
-            return logicalExpression.ToExpressionString(ct);
+            return logicalExpression.ToExpressionString(cancellationToken);
 
-        return logicalExpression.Accept(new ParameterSubstitutionVisitor(Context), ct).TrimEnd();
+        return logicalExpression.Accept(new ParameterSubstitutionVisitor(Context), cancellationToken).TrimEnd();
     }
 }

--- a/src/NCalc.Core/Extensions/LogicalExpressionExtensions.cs
+++ b/src/NCalc.Core/Extensions/LogicalExpressionExtensions.cs
@@ -6,17 +6,17 @@ public static class LogicalExpressionExtensions
 {
     extension(LogicalExpression expression)
     {
-        public ValueTask<object?> EvaluateAsync(ExpressionContext context, CancellationToken ct = default)
+        public ValueTask<object?> EvaluateAsync(ExpressionContext context, CancellationToken cancellationToken = default)
         {
 #if NET
             ArgumentNullException.ThrowIfNull(expression);
 #endif
-            return expression.Accept(new EvaluationVisitor(context), ct);
+            return expression.Accept(new EvaluationVisitor(context), cancellationToken);
         }
 
-        public object? Evaluate(ExpressionContext context, CancellationToken ct = default)
+        public object? Evaluate(ExpressionContext context, CancellationToken cancellationToken = default)
         {
-            var valueTask = expression.EvaluateAsync(context, ct);
+            var valueTask = expression.EvaluateAsync(context, cancellationToken);
 
             if (valueTask.IsCompletedSuccessfully)
                 return valueTask.Result;
@@ -24,12 +24,12 @@ public static class LogicalExpressionExtensions
             return valueTask.AsTask().GetAwaiter().GetResult();
         }
 
-        public string ToExpressionString(CancellationToken ct = default)
+        public string ToExpressionString(CancellationToken cancellationToken = default)
         {
 #if NET
             ArgumentNullException.ThrowIfNull(expression);
 #endif
-            return expression.Accept(new SerializationVisitor(), ct).TrimEnd();
+            return expression.Accept(new SerializationVisitor(), cancellationToken).TrimEnd();
         }
     }
 }

--- a/src/NCalc.Core/Factories/ILogicalExpressionFactory.cs
+++ b/src/NCalc.Core/Factories/ILogicalExpressionFactory.cs
@@ -2,7 +2,7 @@
 
 public interface ILogicalExpressionFactory
 {
-    public LogicalExpression Create(string expression, ExpressionOptions options = ExpressionOptions.None, CancellationToken ct = default);
+    public LogicalExpression Create(string expression, ExpressionOptions options = ExpressionOptions.None, CancellationToken cancellationToken = default);
 
-    public LogicalExpression Create(string expression, CultureInfo cultureInfo, ExpressionOptions options = ExpressionOptions.None, CancellationToken ct = default);
+    public LogicalExpression Create(string expression, CultureInfo cultureInfo, ExpressionOptions options = ExpressionOptions.None, CancellationToken cancellationToken = default);
 }

--- a/src/NCalc.Core/Factories/LogicalExpressionFactory.cs
+++ b/src/NCalc.Core/Factories/LogicalExpressionFactory.cs
@@ -22,11 +22,11 @@ public sealed class LogicalExpressionFactory(ILogger<LogicalExpressionFactory>? 
 
     public static LogicalExpressionFactory GetInstance() => Instance;
 
-    LogicalExpression ILogicalExpressionFactory.Create(string expression, ExpressionOptions options, CancellationToken ct)
+    LogicalExpression ILogicalExpressionFactory.Create(string expression, ExpressionOptions options, CancellationToken cancellationToken)
     {
         try
         {
-            return Create(expression, options, ct);
+            return Create(expression, options, cancellationToken);
         }
         catch (Exception exception)
         {
@@ -35,11 +35,11 @@ public sealed class LogicalExpressionFactory(ILogger<LogicalExpressionFactory>? 
         }
     }
 
-    LogicalExpression ILogicalExpressionFactory.Create(string expression, CultureInfo cultureInfo, ExpressionOptions options, CancellationToken ct)
+    LogicalExpression ILogicalExpressionFactory.Create(string expression, CultureInfo cultureInfo, ExpressionOptions options, CancellationToken cancellationToken)
     {
         try
         {
-            return Create(expression, cultureInfo, options, ct);
+            return Create(expression, cultureInfo, options, cancellationToken);
         }
         catch (Exception exception)
         {
@@ -48,14 +48,14 @@ public sealed class LogicalExpressionFactory(ILogger<LogicalExpressionFactory>? 
         }
     }
 
-    public static LogicalExpression Create(string expression, ExpressionOptions options = ExpressionOptions.None, CancellationToken ct = default)
+    public static LogicalExpression Create(string expression, ExpressionOptions options = ExpressionOptions.None, CancellationToken cancellationToken = default)
     {
-        return Create(expression, CultureInfo.CurrentUICulture, options, ct);
+        return Create(expression, CultureInfo.CurrentUICulture, options, cancellationToken);
     }
 
-    public static LogicalExpression Create(string expression, CultureInfo cultureInfo, ExpressionOptions options = ExpressionOptions.None, CancellationToken ct = default)
+    public static LogicalExpression Create(string expression, CultureInfo cultureInfo, ExpressionOptions options = ExpressionOptions.None, CancellationToken cancellationToken = default)
     {
-        var parserContext = new LogicalExpressionParserContext(expression, LogicalExpressionParserOptions.Create(options, cultureInfo), ct);
+        var parserContext = new LogicalExpressionParserContext(expression, LogicalExpressionParserOptions.Create(options, cultureInfo), cancellationToken);
         return LogicalExpressionParser.Parse(parserContext);
     }
 }

--- a/src/NCalc.Core/Handlers/FunctionData.cs
+++ b/src/NCalc.Core/Handlers/FunctionData.cs
@@ -2,14 +2,14 @@ using NCalc.Extensions;
 
 namespace NCalc.Handlers;
 
-public class FunctionData(Guid id, LogicalExpressionList arguments, ExpressionContext context, CancellationToken ct) : IList<LogicalExpression>
+public class FunctionData(Guid id, LogicalExpressionList arguments, ExpressionContext context, CancellationToken cancellationToken) : IList<LogicalExpression>
 {
     private LogicalExpressionList Arguments { get; } = arguments;
 
     public Guid Id { get; } = id;
 
     public ExpressionContext Context { get; } = context;
-    public CancellationToken CancellationToken { get; } = ct;
+    public CancellationToken CancellationToken { get; } = cancellationToken;
 
     public LogicalExpression this[int index]
     {

--- a/src/NCalc.Core/Handlers/ParameterData.cs
+++ b/src/NCalc.Core/Handlers/ParameterData.cs
@@ -1,8 +1,8 @@
 namespace NCalc.Handlers;
 
-public class ParameterData(Guid id, ExpressionContext context, CancellationToken ct)
+public class ParameterData(Guid id, ExpressionContext context, CancellationToken cancellationToken)
 {
     public Guid Id { get; } = id;
     public ExpressionContext Context { get; } = context;
-    public CancellationToken CancellationToken { get; } = ct;
+    public CancellationToken CancellationToken { get; } = cancellationToken;
 }

--- a/src/NCalc.Core/Handlers/ParameterEventArgs.cs
+++ b/src/NCalc.Core/Handlers/ParameterEventArgs.cs
@@ -1,9 +1,9 @@
 namespace NCalc.Handlers;
 
-public class ParameterEventArgs(Guid id, CancellationToken ct) : EventArgs
+public class ParameterEventArgs(Guid id, CancellationToken cancellationToken) : EventArgs
 {
     public Guid Id { get; } = id;
-    public CancellationToken CancellationToken { get; } = ct;
+    public CancellationToken CancellationToken { get; } = cancellationToken;
 
     public object? Result
     {

--- a/src/NCalc.Core/Visitors/EvaluationVisitor.cs
+++ b/src/NCalc.Core/Visitors/EvaluationVisitor.cs
@@ -12,35 +12,35 @@ namespace NCalc.Visitors;
 /// <param name="context">Contextual parameters of the <see cref="LogicalExpression"/>, like custom functions and parameters.</param>
 public class EvaluationVisitor(ExpressionContext context) : ILogicalExpressionVisitor<ValueTask<object?>>
 {
-    public virtual async ValueTask<object?> Visit(TernaryExpression expression, CancellationToken ct = default)
+    public virtual async ValueTask<object?> Visit(TernaryExpression expression, CancellationToken cancellationToken = default)
     {
         // Evaluates the left expression and saves the value
-        var left = Convert.ToBoolean(await expression.LeftExpression.Accept(this, ct), context.CultureInfo);
+        var left = Convert.ToBoolean(await expression.LeftExpression.Accept(this, cancellationToken), context.CultureInfo);
 
         if (left)
         {
-            return await expression.MiddleExpression.Accept(this, ct);
+            return await expression.MiddleExpression.Accept(this, cancellationToken);
         }
 
-        return await expression.RightExpression.Accept(this, ct);
+        return await expression.RightExpression.Accept(this, cancellationToken);
     }
 
-    public virtual async ValueTask<object?> Visit(BinaryExpression expression, CancellationToken ct = default)
+    public virtual async ValueTask<object?> Visit(BinaryExpression expression, CancellationToken cancellationToken = default)
     {
         if (expression.Type == BinaryExpressionType.And)
         {
-            return Convert.ToBoolean(await EvaluateAsync(expression.LeftExpression, ct), context.CultureInfo) &&
-                   Convert.ToBoolean(await EvaluateAsync(expression.RightExpression, ct), context.CultureInfo);
+            return Convert.ToBoolean(await EvaluateAsync(expression.LeftExpression, cancellationToken), context.CultureInfo) &&
+                   Convert.ToBoolean(await EvaluateAsync(expression.RightExpression, cancellationToken), context.CultureInfo);
         }
 
         if (expression.Type == BinaryExpressionType.Or)
         {
-            return Convert.ToBoolean(await EvaluateAsync(expression.LeftExpression, ct), context.CultureInfo) ||
-                   Convert.ToBoolean(await EvaluateAsync(expression.RightExpression, ct), context.CultureInfo);
+            return Convert.ToBoolean(await EvaluateAsync(expression.LeftExpression, cancellationToken), context.CultureInfo) ||
+                   Convert.ToBoolean(await EvaluateAsync(expression.RightExpression, cancellationToken), context.CultureInfo);
         }
 
-        var left = await EvaluateAsync(expression.LeftExpression, ct);
-        var right = await EvaluateAsync(expression.RightExpression, ct);
+        var left = await EvaluateAsync(expression.LeftExpression, cancellationToken);
+        var right = await EvaluateAsync(expression.RightExpression, cancellationToken);
 
         switch (expression.Type)
         {
@@ -116,21 +116,21 @@ public class EvaluationVisitor(ExpressionContext context) : ILogicalExpressionVi
         return null;
     }
 
-    public virtual async ValueTask<object?> Visit(UnaryExpression expression, CancellationToken ct = default)
+    public virtual async ValueTask<object?> Visit(UnaryExpression expression, CancellationToken cancellationToken = default)
     {
         // Recursively evaluates the underlying expression
-        var result = await expression.Expression.Accept(this, ct);
+        var result = await expression.Expression.Accept(this, cancellationToken);
 
         return Unary(expression, result, context);
     }
 
-    public virtual async ValueTask<object?> Visit(Function function, CancellationToken ct = default)
+    public virtual async ValueTask<object?> Visit(Function function, CancellationToken cancellationToken = default)
     {
         // Don't call parameters right now, instead let the function do it as needed.
         // Some parameters shouldn't be called, for instance, in a if(), the "not" value might be a division by zero
         // Evaluating every value could produce unexpected behaviour
         var functionName = function.Identifier.Name;
-        var functionData = new FunctionData(function.Identifier.Id, function.Parameters, context, ct);
+        var functionData = new FunctionData(function.Identifier.Id, function.Parameters, context, cancellationToken);
         var functionArgs = new FunctionEventArgs(functionData);
 
         // ReSharper disable once MethodHasAsyncOverload
@@ -153,11 +153,11 @@ public class EvaluationVisitor(ExpressionContext context) : ILogicalExpressionVi
         return await BuiltInFunctionHelper.EvaluateAsync(functionName, functionData);
     }
 
-    public virtual async ValueTask<object?> Visit(Identifier identifier, CancellationToken ct = default)
+    public virtual async ValueTask<object?> Visit(Identifier identifier, CancellationToken cancellationToken = default)
     {
         var identifierName = identifier.Name;
 
-        var parameterArgs = new ParameterEventArgs(identifier.Id, ct);
+        var parameterArgs = new ParameterEventArgs(identifier.Id, cancellationToken);
 
         OnEvaluateParameter(identifierName, parameterArgs);
 
@@ -178,14 +178,14 @@ public class EvaluationVisitor(ExpressionContext context) : ILogicalExpressionVi
                 expression.EvaluateFunction += context.EvaluateFunctionHandler;
                 expression.EvaluateParameter += context.EvaluateParameterHandler;
 
-                return await expression.EvaluateAsync(ct);
+                return await expression.EvaluateAsync(cancellationToken);
             }
 
             return parameter;
         }
 
         if (context.DynamicParameters.TryGetValue(identifierName, out var dynamicParameter))
-            return dynamicParameter(new ParameterData(identifier.Id, context, ct));
+            return dynamicParameter(new ParameterData(identifier.Id, context, cancellationToken));
 
         if (identifierName.Equals("null", StringComparison.InvariantCultureIgnoreCase) && context.Options.HasFlag(ExpressionOptions.AllowNullParameter))
             return null;
@@ -193,15 +193,15 @@ public class EvaluationVisitor(ExpressionContext context) : ILogicalExpressionVi
         throw new NCalcParameterNotDefinedException(identifierName);
     }
 
-    public virtual ValueTask<object?> Visit(ValueExpression expression, CancellationToken ct = default) => new(expression.Value);
+    public virtual ValueTask<object?> Visit(ValueExpression expression, CancellationToken cancellationToken = default) => new(expression.Value);
 
-    public virtual async ValueTask<object?> Visit(LogicalExpressionList list, CancellationToken ct = default)
+    public virtual async ValueTask<object?> Visit(LogicalExpressionList list, CancellationToken cancellationToken = default)
     {
         List<object?> result = [];
 
         foreach (var value in list)
         {
-            result.Add(await EvaluateAsync(value, ct));
+            result.Add(await EvaluateAsync(value, cancellationToken));
         }
 
         return result;
@@ -241,8 +241,8 @@ public class EvaluationVisitor(ExpressionContext context) : ILogicalExpressionVi
         context.EvaluateParameterHandler?.Invoke(name, args);
     }
 
-    protected ValueTask<object?> EvaluateAsync(LogicalExpression expression, CancellationToken ct = default)
+    protected ValueTask<object?> EvaluateAsync(LogicalExpression expression, CancellationToken cancellationToken = default)
     {
-        return expression.Accept(this, ct);
+        return expression.Accept(this, cancellationToken);
     }
 }

--- a/src/NCalc.Core/Visitors/FunctionExtractionVisitor.cs
+++ b/src/NCalc.Core/Visitors/FunctionExtractionVisitor.cs
@@ -5,9 +5,9 @@ namespace NCalc.Visitors;
 /// </summary>
 public sealed class FunctionExtractionVisitor : ILogicalExpressionVisitor<List<string>>
 {
-    public List<string> Visit(Identifier identifier, CancellationToken ct = default) => [];
+    public List<string> Visit(Identifier identifier, CancellationToken cancellationToken = default) => [];
 
-    public List<string> Visit(LogicalExpressionList list, CancellationToken ct = default)
+    public List<string> Visit(LogicalExpressionList list, CancellationToken cancellationToken = default)
     {
         var functions = new List<string>();
         foreach (var value in list)
@@ -23,50 +23,50 @@ public sealed class FunctionExtractionVisitor : ILogicalExpressionVisitor<List<s
                 {
                     if (parameter is not null)
                     {
-                        functions.AddRange(parameter.Accept(this, ct));
+                        functions.AddRange(parameter.Accept(this, cancellationToken));
                     }
                 }
             }
             else
             {
-                functions.AddRange(value.Accept(this, ct));
+                functions.AddRange(value.Accept(this, cancellationToken));
             }
         }
         return functions;
     }
 
-    public List<string> Visit(UnaryExpression expression, CancellationToken ct = default) =>
-        expression.Expression.Accept(this, ct);
+    public List<string> Visit(UnaryExpression expression, CancellationToken cancellationToken = default) =>
+        expression.Expression.Accept(this, cancellationToken);
 
-    public List<string> Visit(BinaryExpression expression, CancellationToken ct = default)
+    public List<string> Visit(BinaryExpression expression, CancellationToken cancellationToken = default)
     {
-        var leftParameters = expression.LeftExpression.Accept(this, ct);
-        var rightParameters = expression.RightExpression.Accept(this, ct);
+        var leftParameters = expression.LeftExpression.Accept(this, cancellationToken);
+        var rightParameters = expression.RightExpression.Accept(this, cancellationToken);
 
         leftParameters.AddRange(rightParameters);
         return leftParameters.Distinct().ToList();
     }
 
-    public List<string> Visit(TernaryExpression expression, CancellationToken ct = default)
+    public List<string> Visit(TernaryExpression expression, CancellationToken cancellationToken = default)
     {
-        var leftParameters = expression.LeftExpression.Accept(this, ct);
-        var middleParameters = expression.MiddleExpression.Accept(this, ct);
-        var rightParameters = expression.RightExpression.Accept(this, ct);
+        var leftParameters = expression.LeftExpression.Accept(this, cancellationToken);
+        var middleParameters = expression.MiddleExpression.Accept(this, cancellationToken);
+        var rightParameters = expression.RightExpression.Accept(this, cancellationToken);
 
         leftParameters.AddRange(middleParameters);
         leftParameters.AddRange(rightParameters);
         return leftParameters.Distinct().ToList();
     }
 
-    public List<string> Visit(Function function, CancellationToken ct = default)
+    public List<string> Visit(Function function, CancellationToken cancellationToken = default)
     {
         var functions = new List<string> { function.Identifier.Name };
 
-        var innerFunctions = function.Parameters.Accept(this, ct);
+        var innerFunctions = function.Parameters.Accept(this, cancellationToken);
         functions.AddRange(innerFunctions);
 
         return functions.Distinct().ToList();
     }
 
-    public List<string> Visit(ValueExpression expression, CancellationToken ct = default) => [];
+    public List<string> Visit(ValueExpression expression, CancellationToken cancellationToken = default) => [];
 }

--- a/src/NCalc.Core/Visitors/ParameterExtractionVisitor.cs
+++ b/src/NCalc.Core/Visitors/ParameterExtractionVisitor.cs
@@ -5,9 +5,9 @@
 /// </summary>
 public sealed class ParameterExtractionVisitor : ILogicalExpressionVisitor<List<string>>
 {
-    public List<string> Visit(Identifier identifier, CancellationToken ct = default) => [identifier.Name];
+    public List<string> Visit(Identifier identifier, CancellationToken cancellationToken = default) => [identifier.Name];
 
-    public List<string> Visit(LogicalExpressionList list, CancellationToken ct = default)
+    public List<string> Visit(LogicalExpressionList list, CancellationToken cancellationToken = default)
     {
         var parameters = new List<string>();
         foreach (var value in list)
@@ -21,44 +21,44 @@ public sealed class ParameterExtractionVisitor : ILogicalExpressionVisitor<List<
             }
             else
             {
-                parameters.AddRange(value.Accept(this, ct));
+                parameters.AddRange(value.Accept(this, cancellationToken));
             }
         }
         return parameters;
     }
 
-    public List<string> Visit(UnaryExpression expression, CancellationToken ct = default) =>
-        expression.Expression.Accept(this, ct);
+    public List<string> Visit(UnaryExpression expression, CancellationToken cancellationToken = default) =>
+        expression.Expression.Accept(this, cancellationToken);
 
-    public List<string> Visit(BinaryExpression expression, CancellationToken ct = default)
+    public List<string> Visit(BinaryExpression expression, CancellationToken cancellationToken = default)
     {
-        var leftParameters = expression.LeftExpression.Accept(this, ct);
-        var rightParameters = expression.RightExpression.Accept(this, ct);
+        var leftParameters = expression.LeftExpression.Accept(this, cancellationToken);
+        var rightParameters = expression.RightExpression.Accept(this, cancellationToken);
 
         leftParameters.AddRange(rightParameters);
         return leftParameters.Distinct().ToList();
     }
 
-    public List<string> Visit(TernaryExpression expression, CancellationToken ct = default)
+    public List<string> Visit(TernaryExpression expression, CancellationToken cancellationToken = default)
     {
-        var leftParameters = expression.LeftExpression.Accept(this, ct);
-        var middleParameters = expression.MiddleExpression.Accept(this, ct);
-        var rightParameters = expression.RightExpression.Accept(this, ct);
+        var leftParameters = expression.LeftExpression.Accept(this, cancellationToken);
+        var middleParameters = expression.MiddleExpression.Accept(this, cancellationToken);
+        var rightParameters = expression.RightExpression.Accept(this, cancellationToken);
 
         leftParameters.AddRange(middleParameters);
         leftParameters.AddRange(rightParameters);
         return leftParameters.Distinct().ToList();
     }
 
-    public List<string> Visit(Function function, CancellationToken ct = default)
+    public List<string> Visit(Function function, CancellationToken cancellationToken = default)
     {
         var parameters = new List<string>();
 
-        var innerParameters = function.Parameters.Accept(this, ct);
+        var innerParameters = function.Parameters.Accept(this, cancellationToken);
         parameters.AddRange(innerParameters);
 
         return parameters.Distinct().ToList();
     }
 
-    public List<string> Visit(ValueExpression expression, CancellationToken ct = default) => [];
+    public List<string> Visit(ValueExpression expression, CancellationToken cancellationToken = default) => [];
 }

--- a/src/NCalc.Core/Visitors/ParameterSubstitutionVisitor.cs
+++ b/src/NCalc.Core/Visitors/ParameterSubstitutionVisitor.cs
@@ -8,26 +8,26 @@ namespace NCalc.Visitors;
 /// </summary>
 public class ParameterSubstitutionVisitor(ExpressionContext context) : SerializationVisitor
 {
-    public override string Visit(Identifier identifier, CancellationToken ct = default)
+    public override string Visit(Identifier identifier, CancellationToken cancellationToken = default)
     {
-        if (TryEvaluateIdentifier(identifier, ct, out var value))
-            return SerializeValue(value, ct);
+        if (TryEvaluateIdentifier(identifier, cancellationToken, out var value))
+            return SerializeValue(value, cancellationToken);
 
-        return base.Visit(identifier, ct);
+        return base.Visit(identifier, cancellationToken);
     }
 
-    protected override string EncapsulateNoValue(LogicalExpression expression, CancellationToken ct = default)
+    protected override string EncapsulateNoValue(LogicalExpression expression, CancellationToken cancellationToken = default)
     {
         if (expression is Identifier identifier)
-            return $"{Visit(identifier, ct).TrimEnd()} ";
+            return $"{Visit(identifier, cancellationToken).TrimEnd()} ";
 
-        return base.EncapsulateNoValue(expression, ct);
+        return base.EncapsulateNoValue(expression, cancellationToken);
     }
 
-    private bool TryEvaluateIdentifier(Identifier identifier, CancellationToken ct, out object? value)
+    private bool TryEvaluateIdentifier(Identifier identifier, CancellationToken cancellationToken, out object? value)
     {
         var identifierName = identifier.Name;
-        var parameterArgs = new ParameterEventArgs(identifier.Id, ct);
+        var parameterArgs = new ParameterEventArgs(identifier.Id, cancellationToken);
 
         context.EvaluateParameterHandler?.Invoke(identifierName, parameterArgs);
 
@@ -42,7 +42,7 @@ public class ParameterSubstitutionVisitor(ExpressionContext context) : Serializa
 
         if (context.DynamicParameters.TryGetValue(identifierName, out var dynamicParameter))
         {
-            value = dynamicParameter(new ParameterData(identifier.Id, context, ct));
+            value = dynamicParameter(new ParameterData(identifier.Id, context, cancellationToken));
             return true;
         }
 
@@ -57,7 +57,7 @@ public class ParameterSubstitutionVisitor(ExpressionContext context) : Serializa
         return false;
     }
 
-    private string SerializeValue(object? value, CancellationToken ct)
+    private string SerializeValue(object? value, CancellationToken cancellationToken)
     {
         while (true)
         {
@@ -66,11 +66,11 @@ public class ParameterSubstitutionVisitor(ExpressionContext context) : Serializa
 
             if (value is Expression expression)
             {
-                value = expression.Evaluate(ct);
+                value = expression.Evaluate(cancellationToken);
                 continue;
             }
 
-            return new ValueExpression(value).Accept(this, ct).TrimEnd(' ');
+            return new ValueExpression(value).Accept(this, cancellationToken).TrimEnd(' ');
         }
     }
 }

--- a/src/NCalc.Core/Visitors/SerializationVisitor.cs
+++ b/src/NCalc.Core/Visitors/SerializationVisitor.cs
@@ -10,18 +10,18 @@ public class SerializationVisitor : ILogicalExpressionVisitor<string>
         NumberDecimalSeparator = "."
     };
 
-    public virtual string Visit(TernaryExpression expression, CancellationToken ct = default)
+    public virtual string Visit(TernaryExpression expression, CancellationToken cancellationToken = default)
     {
-        string result = EncapsulateNoValue(expression.LeftExpression, ct) + "? ";
-        result += EncapsulateNoValue(expression.MiddleExpression, ct) + ": ";
-        result += EncapsulateNoValue(expression.RightExpression, ct);
+        string result = EncapsulateNoValue(expression.LeftExpression, cancellationToken) + "? ";
+        result += EncapsulateNoValue(expression.MiddleExpression, cancellationToken) + ": ";
+        result += EncapsulateNoValue(expression.RightExpression, cancellationToken);
 
         return result;
     }
 
-    public virtual string Visit(BinaryExpression expression, CancellationToken ct = default)
+    public virtual string Visit(BinaryExpression expression, CancellationToken cancellationToken = default)
     {
-        string result = EncapsulateNoValue(expression.LeftExpression, ct);
+        string result = EncapsulateNoValue(expression.LeftExpression, cancellationToken);
 
         result += expression.Type switch
         {
@@ -52,11 +52,11 @@ public class SerializationVisitor : ILogicalExpressionVisitor<string>
             _ => throw new ArgumentOutOfRangeException()
         };
 
-        result += EncapsulateNoValue(expression.RightExpression, ct);
+        result += EncapsulateNoValue(expression.RightExpression, cancellationToken);
         return result;
     }
 
-    public virtual string Visit(UnaryExpression expression, CancellationToken ct = default)
+    public virtual string Visit(UnaryExpression expression, CancellationToken cancellationToken = default)
     {
         string result = expression.Type switch
         {
@@ -66,11 +66,11 @@ public class SerializationVisitor : ILogicalExpressionVisitor<string>
             _ => string.Empty
         };
 
-        result += EncapsulateNoValue(expression.Expression, ct);
+        result += EncapsulateNoValue(expression.Expression, cancellationToken);
         return result;
     }
 
-    public virtual string Visit(ValueExpression expression, CancellationToken ct = default)
+    public virtual string Visit(ValueExpression expression, CancellationToken cancellationToken = default)
     {
         return expression.Type switch
         {
@@ -82,13 +82,13 @@ public class SerializationVisitor : ILogicalExpressionVisitor<string>
         };
     }
 
-    public virtual string Visit(Function function, CancellationToken ct = default)
+    public virtual string Visit(Function function, CancellationToken cancellationToken = default)
     {
         var resultBuilder = new StringBuilder(function.Identifier.Name + '(');
 
         for (int i = 0; i < function.Parameters.Count; i++)
         {
-            resultBuilder.Append(function.Parameters[i].Accept(this, ct));
+            resultBuilder.Append(function.Parameters[i].Accept(this, cancellationToken));
             if (i < function.Parameters.Count - 1)
             {
                 if (resultBuilder[^1] == ' ')
@@ -105,17 +105,17 @@ public class SerializationVisitor : ILogicalExpressionVisitor<string>
         return resultBuilder.ToString();
     }
 
-    public virtual string Visit(Identifier identifier, CancellationToken ct = default)
+    public virtual string Visit(Identifier identifier, CancellationToken cancellationToken = default)
     {
         return $"[{identifier.Name}]";
     }
 
-    public virtual string Visit(LogicalExpressionList list, CancellationToken ct = default)
+    public virtual string Visit(LogicalExpressionList list, CancellationToken cancellationToken = default)
     {
         var resultBuilder = new StringBuilder("(");
         for (var i = 0; i < list.Count; i++)
         {
-            resultBuilder.Append(list[i].Accept(this, ct).TrimEnd());
+            resultBuilder.Append(list[i].Accept(this, cancellationToken).TrimEnd());
             if (i < list.Count - 1)
             {
                 resultBuilder.Append(',');
@@ -125,12 +125,12 @@ public class SerializationVisitor : ILogicalExpressionVisitor<string>
         return resultBuilder.ToString();
     }
 
-    protected virtual string EncapsulateNoValue(LogicalExpression expression, CancellationToken ct = default)
+    protected virtual string EncapsulateNoValue(LogicalExpression expression, CancellationToken cancellationToken = default)
     {
         if (expression is ValueExpression valueExpression)
-            return valueExpression.Accept(this, ct);
+            return valueExpression.Accept(this, cancellationToken);
 
-        string result = expression.Accept(this, ct);
+        string result = expression.Accept(this, cancellationToken);
         return $"({result.TrimEnd(' ')}) ";
     }
 }

--- a/src/NCalc.Domain/BinaryExpression.cs
+++ b/src/NCalc.Domain/BinaryExpression.cs
@@ -13,8 +13,8 @@ public sealed class BinaryExpression(
 
     public BinaryExpressionType Type { get; set; } = type;
 
-    public override T Accept<T>(ILogicalExpressionVisitor<T> visitor, CancellationToken ct = default)
+    public override T Accept<T>(ILogicalExpressionVisitor<T> visitor, CancellationToken cancellationToken = default)
     {
-        return visitor.Visit(this, ct);
+        return visitor.Visit(this, cancellationToken);
     }
 }

--- a/src/NCalc.Domain/Function.cs
+++ b/src/NCalc.Domain/Function.cs
@@ -8,8 +8,8 @@ public sealed class Function(Identifier identifier, LogicalExpressionList parame
 
     public LogicalExpressionList Parameters { get; set; } = parameters;
 
-    public override T Accept<T>(ILogicalExpressionVisitor<T> visitor, CancellationToken ct = default)
+    public override T Accept<T>(ILogicalExpressionVisitor<T> visitor, CancellationToken cancellationToken = default)
     {
-        return visitor.Visit(this, ct);
+        return visitor.Visit(this, cancellationToken);
     }
 }

--- a/src/NCalc.Domain/Identifier.cs
+++ b/src/NCalc.Domain/Identifier.cs
@@ -7,8 +7,8 @@ public sealed class Identifier(string name) : LogicalExpression
     public Guid Id { get; } = Guid.NewGuid();
     public string Name { get; set; } = name;
 
-    public override T Accept<T>(ILogicalExpressionVisitor<T> visitor, CancellationToken ct = default)
+    public override T Accept<T>(ILogicalExpressionVisitor<T> visitor, CancellationToken cancellationToken = default)
     {
-        return visitor.Visit(this, ct);
+        return visitor.Visit(this, cancellationToken);
     }
 }

--- a/src/NCalc.Domain/LogicalExpression.cs
+++ b/src/NCalc.Domain/LogicalExpression.cs
@@ -19,5 +19,5 @@ namespace NCalc;
 public abstract class LogicalExpression
 {
     [Pure]
-    public abstract T Accept<T>(ILogicalExpressionVisitor<T> visitor, CancellationToken ct = default);
+    public abstract T Accept<T>(ILogicalExpressionVisitor<T> visitor, CancellationToken cancellationToken = default);
 }

--- a/src/NCalc.Domain/LogicalExpressionList.cs
+++ b/src/NCalc.Domain/LogicalExpressionList.cs
@@ -75,8 +75,8 @@ public sealed class LogicalExpressionList : LogicalExpression, IList<LogicalExpr
         _list.RemoveAt(index);
     }
 
-    public override T Accept<T>(ILogicalExpressionVisitor<T> visitor, CancellationToken ct = default)
+    public override T Accept<T>(ILogicalExpressionVisitor<T> visitor, CancellationToken cancellationToken = default)
     {
-        return visitor.Visit(this, ct);
+        return visitor.Visit(this, cancellationToken);
     }
 }

--- a/src/NCalc.Domain/TernaryExpression.cs
+++ b/src/NCalc.Domain/TernaryExpression.cs
@@ -14,8 +14,8 @@ public sealed class TernaryExpression(
 
     public LogicalExpression RightExpression { get; set; } = rightExpression;
 
-    public override T Accept<T>(ILogicalExpressionVisitor<T> visitor, CancellationToken ct = default)
+    public override T Accept<T>(ILogicalExpressionVisitor<T> visitor, CancellationToken cancellationToken = default)
     {
-        return visitor.Visit(this, ct);
+        return visitor.Visit(this, cancellationToken);
     }
 }

--- a/src/NCalc.Domain/UnaryExpression.cs
+++ b/src/NCalc.Domain/UnaryExpression.cs
@@ -8,8 +8,8 @@ public sealed class UnaryExpression(UnaryExpressionType type, LogicalExpression 
 
     public UnaryExpressionType Type { get; set; } = type;
 
-    public override T Accept<T>(ILogicalExpressionVisitor<T> visitor, CancellationToken ct = default)
+    public override T Accept<T>(ILogicalExpressionVisitor<T> visitor, CancellationToken cancellationToken = default)
     {
-        return visitor.Visit(this, ct);
+        return visitor.Visit(this, cancellationToken);
     }
 }

--- a/src/NCalc.Domain/ValueExpression.cs
+++ b/src/NCalc.Domain/ValueExpression.cs
@@ -128,8 +128,8 @@ public sealed class ValueExpression : LogicalExpression , IJsonOnDeserialized
         return value[0];
     }
 
-    public override T Accept<T>(ILogicalExpressionVisitor<T> visitor, CancellationToken ct = default)
+    public override T Accept<T>(ILogicalExpressionVisitor<T> visitor, CancellationToken cancellationToken = default)
     {
-        return visitor.Visit(this, ct);
+        return visitor.Visit(this, cancellationToken);
     }
 }

--- a/src/NCalc.Domain/Visitors/ILogicalExpressionVisitor.cs
+++ b/src/NCalc.Domain/Visitors/ILogicalExpressionVisitor.cs
@@ -6,11 +6,11 @@ namespace NCalc.Visitors;
 /// <typeparam name="T">The type of result returned from each visit method.</typeparam>
 public interface ILogicalExpressionVisitor<out T>
 {
-    T Visit(TernaryExpression expression, CancellationToken ct = default);
-    T Visit(BinaryExpression expression, CancellationToken ct = default);
-    T Visit(UnaryExpression expression, CancellationToken ct = default);
-    T Visit(ValueExpression expression, CancellationToken ct = default);
-    T Visit(Function function, CancellationToken ct = default);
-    T Visit(Identifier identifier, CancellationToken ct = default);
-    T Visit(LogicalExpressionList list, CancellationToken ct = default);
+    T Visit(TernaryExpression expression, CancellationToken cancellationToken = default);
+    T Visit(BinaryExpression expression, CancellationToken cancellationToken = default);
+    T Visit(UnaryExpression expression, CancellationToken cancellationToken = default);
+    T Visit(ValueExpression expression, CancellationToken cancellationToken = default);
+    T Visit(Function function, CancellationToken cancellationToken = default);
+    T Visit(Identifier identifier, CancellationToken cancellationToken = default);
+    T Visit(LogicalExpressionList list, CancellationToken cancellationToken = default);
 }

--- a/src/NCalc.Parser/LogicalExpressionParserContext.cs
+++ b/src/NCalc.Parser/LogicalExpressionParserContext.cs
@@ -5,13 +5,13 @@ namespace NCalc.Parser;
 
 public sealed class LogicalExpressionParserContext : ParseContext
 {
-    public LogicalExpressionParserContext(string text, CancellationToken ct = default) : this(text, new LogicalExpressionParserOptions(), ct)
+    public LogicalExpressionParserContext(string text, CancellationToken cancellationToken = default) : this(text, new LogicalExpressionParserOptions(), cancellationToken)
     {
     }
 
     public LogicalExpressionParserContext(string text,
         LogicalExpressionParserOptions parserOptions,
-        CancellationToken ct = default) : base(new Scanner(text), useNewLines:false, disableLoopDetection:true, ct)
+        CancellationToken cancellationToken = default) : base(new Scanner(text), useNewLines:false, disableLoopDetection:true, cancellationToken)
     {
         ParserOptions = parserOptions;
     }

--- a/src/Plugins/NCalc.Antlr/AntlrLogicalExpressionFactory.cs
+++ b/src/Plugins/NCalc.Antlr/AntlrLogicalExpressionFactory.cs
@@ -9,7 +9,7 @@ namespace NCalc.Antlr;
 /// </summary>
 public sealed class AntlrLogicalExpressionFactory : ILogicalExpressionFactory
 {
-    public LogicalExpression Create(string expression, ExpressionOptions options, CancellationToken ct)
+    public LogicalExpression Create(string expression, ExpressionOptions options, CancellationToken cancellationToken)
     {
         LogicalExpression logicalExpression;
         var lexer = new NCalcLexer(new AntlrInputStream(expression));
@@ -56,8 +56,8 @@ public sealed class AntlrLogicalExpressionFactory : ILogicalExpressionFactory
         return logicalExpression;
     }
 
-    public LogicalExpression Create(string expression, CultureInfo cultureInfo, ExpressionOptions options = ExpressionOptions.None, CancellationToken ct = default)
+    public LogicalExpression Create(string expression, CultureInfo cultureInfo, ExpressionOptions options = ExpressionOptions.None, CancellationToken cancellationToken = default)
     {
-        return Create(expression, options, ct);
+        return Create(expression, options, cancellationToken);
     }
 }

--- a/src/Plugins/NCalc.LambdaCompilation/LambdaCompilationExtensions.cs
+++ b/src/Plugins/NCalc.LambdaCompilation/LambdaCompilationExtensions.cs
@@ -19,9 +19,9 @@ public static class LambdaCompilationExtensions
 #if !DOCFX
      extension(Expression expression)
     {
-        public Func<TResult> ToLambda<TResult>(CancellationToken ct = default)
+        public Func<TResult> ToLambda<TResult>(CancellationToken cancellationToken = default)
         {
-            var body = expression.ToLinqExpression<TResult>(ct);
+            var body = expression.ToLinqExpression<TResult>(cancellationToken);
             var lambda = LinqExpression.Lambda<Func<TResult>>(body);
 
             if (UseSystemLinqCompiler)
@@ -30,9 +30,9 @@ public static class LambdaCompilationExtensions
             return lambda.CompileFast();
         }
 
-        public Func<TContext, TResult> ToLambda<TContext, TResult>(CancellationToken ct = default)
+        public Func<TContext, TResult> ToLambda<TContext, TResult>(CancellationToken cancellationToken = default)
         {
-            var linqExp = expression.ToLinqExpression<TContext, TResult>(ct);
+            var linqExp = expression.ToLinqExpression<TContext, TResult>(cancellationToken);
             if (linqExp.Parameter != null)
             {
                 var lambda = LinqExpression.Lambda<Func<TContext, TResult>>(linqExp.Expression, linqExp.Parameter);
@@ -46,19 +46,19 @@ public static class LambdaCompilationExtensions
             throw new NCalcException("Linq expression parameter cannot be null");
         }
 
-        public LinqExpression ToLinqExpression<TResult>(CancellationToken ct = default)
+        public LinqExpression ToLinqExpression<TResult>(CancellationToken cancellationToken = default)
         {
-            return expression.ToLinqExpressionInternal<Void, TResult>(ct).Expression;
+            return expression.ToLinqExpressionInternal<Void, TResult>(cancellationToken).Expression;
         }
 
-        public LinqExpressionWithParameter ToLinqExpression<TContext, TResult>(CancellationToken ct = default)
+        public LinqExpressionWithParameter ToLinqExpression<TContext, TResult>(CancellationToken cancellationToken = default)
         {
-            return expression.ToLinqExpressionInternal<TContext, TResult>(ct);
+            return expression.ToLinqExpressionInternal<TContext, TResult>(cancellationToken);
         }
 
-        private LinqExpressionWithParameter ToLinqExpressionInternal<TContext, TResult>(CancellationToken ct)
+        private LinqExpressionWithParameter ToLinqExpressionInternal<TContext, TResult>(CancellationToken cancellationToken)
         {
-            expression.LogicalExpression ??= expression.GetLogicalExpression(ct);
+            expression.LogicalExpression ??= expression.GetLogicalExpression(cancellationToken);
 
             if (expression.LogicalExpression is null)
                 throw expression.Error!;
@@ -75,7 +75,7 @@ public static class LambdaCompilationExtensions
                 visitor = new(parameter, expression.Options);
             }
 
-            var body = expression.LogicalExpression.Accept(visitor, ct);
+            var body = expression.LogicalExpression.Accept(visitor, cancellationToken);
             if (!IsSameType(body, typeof(TResult)))
             {
                 body = LinqExpression.Convert(body, typeof(TResult));

--- a/src/Plugins/NCalc.LambdaCompilation/Visitors/LambdaExpressionVisitor.cs
+++ b/src/Plugins/NCalc.LambdaCompilation/Visitors/LambdaExpressionVisitor.cs
@@ -47,19 +47,19 @@ public sealed class LambdaExpressionVisitor : ILogicalExpressionVisitor<LinqExpr
         _context = context;
     }
 
-    public LinqExpression Visit(TernaryExpression expression, CancellationToken ct = default)
+    public LinqExpression Visit(TernaryExpression expression, CancellationToken cancellationToken = default)
     {
-        var conditional = expression.LeftExpression.Accept(this, ct);
-        var ifTrue = expression.MiddleExpression.Accept(this, ct);
-        var ifFalse = expression.RightExpression.Accept(this, ct);
+        var conditional = expression.LeftExpression.Accept(this, cancellationToken);
+        var ifTrue = expression.MiddleExpression.Accept(this, cancellationToken);
+        var ifFalse = expression.RightExpression.Accept(this, cancellationToken);
 
         return LinqExpression.Condition(conditional, ifTrue, ifFalse);
     }
 
-    public LinqExpression Visit(BinaryExpression expression, CancellationToken ct = default)
+    public LinqExpression Visit(BinaryExpression expression, CancellationToken cancellationToken = default)
     {
-        var left = expression.LeftExpression.Accept(this, ct);
-        var right = expression.RightExpression.Accept(this, ct);
+        var left = expression.LeftExpression.Accept(this, cancellationToken);
+        var right = expression.RightExpression.Accept(this, cancellationToken);
 
         return expression.Type switch
         {
@@ -91,9 +91,9 @@ public sealed class LambdaExpressionVisitor : ILogicalExpressionVisitor<LinqExpr
         };
     }
 
-    public LinqExpression Visit(UnaryExpression expression, CancellationToken ct = default)
+    public LinqExpression Visit(UnaryExpression expression, CancellationToken cancellationToken = default)
     {
-        var operand = expression.Expression.Accept(this, ct);
+        var operand = expression.Expression.Accept(this, cancellationToken);
 
         return expression.Type switch
         {
@@ -105,17 +105,17 @@ public sealed class LambdaExpressionVisitor : ILogicalExpressionVisitor<LinqExpr
         };
     }
 
-    public LinqExpression Visit(ValueExpression expression, CancellationToken ct = default)
+    public LinqExpression Visit(ValueExpression expression, CancellationToken cancellationToken = default)
     {
         return LinqExpression.Constant(expression.Value);
     }
 
-    public LinqExpression Visit(Function function, CancellationToken ct = default)
+    public LinqExpression Visit(Function function, CancellationToken cancellationToken = default)
     {
         var args = new LinqExpression[function.Parameters.Count];
         for (var i = 0; i < function.Parameters.Count; i++)
         {
-            args[i] = function.Parameters[i].Accept(this, ct);
+            args[i] = function.Parameters[i].Accept(this, cancellationToken);
         }
 
         // Context methods take precedence over built-in functions because they're user-customizable.
@@ -236,7 +236,7 @@ public sealed class LambdaExpressionVisitor : ILogicalExpressionVisitor<LinqExpr
         }
     }
 
-    public LinqExpression Visit(Identifier identifier, CancellationToken ct = default)
+    public LinqExpression Visit(Identifier identifier, CancellationToken cancellationToken = default)
     {
         var identifierName = identifier.Name;
 
@@ -251,11 +251,11 @@ public sealed class LambdaExpressionVisitor : ILogicalExpressionVisitor<LinqExpr
         return LinqExpression.PropertyOrField(_context, identifierName);
     }
 
-    public LinqExpression Visit(LogicalExpressionList list, CancellationToken ct = default)
+    public LinqExpression Visit(LogicalExpressionList list, CancellationToken cancellationToken = default)
     {
         var newList = LinqExpression.New(typeof(List<object>));
         return LinqExpression.ListInit(newList,
-            list.Select(e => LinqExpression.Convert(e.Accept(this, ct), typeof(object)))
+            list.Select(e => LinqExpression.Convert(e.Accept(this, cancellationToken), typeof(object)))
         );
     }
 

--- a/test/NCalc.Tests/AsyncTests.cs
+++ b/test/NCalc.Tests/AsyncTests.cs
@@ -141,7 +141,7 @@ public class AsyncTests
     [MethodDataSource(typeof(WaterLevelCheckTestData), "GetEnumerator")]
     public async Task SerializeAndDeserializeShouldWork(string expression, bool expected, double inputValue)
     {
-        var compiled = LogicalExpressionFactory.Create(expression, ct: CancellationToken.None);
+        var compiled = LogicalExpressionFactory.Create(expression, cancellationToken: CancellationToken.None);
         var serialized = JsonSerializer.Serialize(compiled);
         var deserialized = JsonSerializer.Deserialize<LogicalExpression>(serialized);
 

--- a/test/NCalc.Tests/ExceptionsTests.cs
+++ b/test/NCalc.Tests/ExceptionsTests.cs
@@ -88,19 +88,19 @@ public class ExceptionsTests
     [Test]
     public async Task Should_Throw_Exception_On_Lexer_Errors_Issue_6()
     {
-        Assert.Throws<NCalcParserException>(() => LogicalExpressionFactory.Create("#t -chers", ct: CancellationToken.None));
+        Assert.Throws<NCalcParserException>(() => LogicalExpressionFactory.Create("#t -chers", cancellationToken: CancellationToken.None));
 
         var dateSeparator = CultureInfo.CurrentCulture.DateTimeFormat.DateSeparator;
         string dateStr = $"#13{dateSeparator}13{dateSeparator}2222#";
         var invalidDateException = Assert.Throws<FormatException>(() =>
-            LogicalExpressionFactory.Create(dateStr, ct: CancellationToken.None));
+            LogicalExpressionFactory.Create(dateStr, cancellationToken: CancellationToken.None));
         await Assert.That(invalidDateException).IsTypeOf<FormatException>();
 
         //At v4, DateTime is better handled, and this should no longer cause errors.
         // https://github.com/ncalc/ncalc-async/issues/6
         try
         {
-            LogicalExpressionFactory.Create("Format(\"{0:(###) ###-####}\", \"9999999999\")", ct: CancellationToken.None);
+            LogicalExpressionFactory.Create("Format(\"{0:(###) ###-####}\", \"9999999999\")", cancellationToken: CancellationToken.None);
         }
         catch
         {

--- a/test/NCalc.Tests/FactoriesTests.cs
+++ b/test/NCalc.Tests/FactoriesTests.cs
@@ -19,7 +19,7 @@ public class FactoriesTests(FactoriesFixture fixture)
     [Test]
     public async Task Logical_Expression_From_Factory_Should_Evaluate()
     {
-        await Assert.That(_expressionFactory.Create(_logicalExpressionFactory.Create("2+2", ct: CancellationToken.None))
+        await Assert.That(_expressionFactory.Create(_logicalExpressionFactory.Create("2+2", cancellationToken: CancellationToken.None))
             .Evaluate(CancellationToken.None)).IsEqualTo(4);
     }
 }

--- a/test/NCalc.Tests/OperatorsTests.cs
+++ b/test/NCalc.Tests/OperatorsTests.cs
@@ -11,7 +11,7 @@ public class OperatorsTests
     [Arguments("not true")]
     public async Task Should_Evaluate_Not_Unary_Operator(string expression)
     {
-        var logicalExpression = LogicalExpressionFactory.Create(expression, ct: CancellationToken.None);
+        var logicalExpression = LogicalExpressionFactory.Create(expression, cancellationToken: CancellationToken.None);
         var expr = new Expression(logicalExpression);
         await Assert.That((bool)expr.Evaluate(CancellationToken.None)!).IsFalse();
     }
@@ -92,7 +92,7 @@ public class OperatorsTests
     [Test]
     public async Task Should_Use_Correct_BitwiseXOr_133()
     {
-        var logicalExpression = LogicalExpressionFactory.Create(expression: "1 ^ 2", ct: CancellationToken.None);
+        var logicalExpression = LogicalExpressionFactory.Create(expression: "1 ^ 2", cancellationToken: CancellationToken.None);
 
         var serializedString = logicalExpression.ToExpressionString();
 

--- a/test/NCalc.Tests/ParserTests.cs
+++ b/test/NCalc.Tests/ParserTests.cs
@@ -53,7 +53,7 @@ public class ParserTests
     {
         const string formula = "[{Diagnostic}.Data]";
 
-        var logicalExpression = LogicalExpressionFactory.Create(formula, ct: CancellationToken.None);
+        var logicalExpression = LogicalExpressionFactory.Create(formula, cancellationToken: CancellationToken.None);
 
         await Assert.That(logicalExpression).IsTypeOf<Identifier>();
 
@@ -65,7 +65,7 @@ public class ParserTests
     {
         const string formula = "'c'";
 
-        var logicalExpression = LogicalExpressionFactory.Create(formula, ExpressionOptions.AllowCharValues, ct: CancellationToken.None);
+        var logicalExpression = LogicalExpressionFactory.Create(formula, ExpressionOptions.AllowCharValues, cancellationToken: CancellationToken.None);
 
         await Assert.That(logicalExpression).IsTypeOf<ValueExpression>();
 
@@ -79,7 +79,7 @@ public class ParserTests
     [Test]
     public async Task ShouldHandleBinaryExpression(string formula, int expectedResult)
     {
-        var logicalExpression = LogicalExpressionFactory.Create(formula, ct: CancellationToken.None);
+        var logicalExpression = LogicalExpressionFactory.Create(formula, cancellationToken: CancellationToken.None);
 
         await Assert.That(logicalExpression).IsTypeOf<BinaryExpression>();
 
@@ -94,7 +94,7 @@ public class ParserTests
     [Test]
     public async Task ShouldParseLists(string formula, int arrayExpectedCount)
     {
-        var logicalExpression = LogicalExpressionFactory.Create(formula, ct: CancellationToken.None);
+        var logicalExpression = LogicalExpressionFactory.Create(formula, cancellationToken: CancellationToken.None);
 
         await Assert.That(logicalExpression).IsTypeOf<LogicalExpressionList>();
 
@@ -115,7 +115,7 @@ public class ParserTests
     [Test]
     public async Task ShouldParseGuids(string formula)
     {
-        var logicalExpression = LogicalExpressionFactory.Create(formula, ct: CancellationToken.None);
+        var logicalExpression = LogicalExpressionFactory.Create(formula, cancellationToken: CancellationToken.None);
 
         await Assert.That(logicalExpression).IsTypeOf<ValueExpression>();
 
@@ -125,7 +125,7 @@ public class ParserTests
     [Test]
     public async Task ShouldParseGuidInsideFunction()
     {
-        var logicalExpression = LogicalExpressionFactory.Create("getUser(78b1941f4e7941c9bef656fad7326538)", ct: CancellationToken.None);
+        var logicalExpression = LogicalExpressionFactory.Create("getUser(78b1941f4e7941c9bef656fad7326538)", cancellationToken: CancellationToken.None);
 
         if (logicalExpression is Function function)
         {

--- a/test/NCalc.Tests/SerializationTests.cs
+++ b/test/NCalc.Tests/SerializationTests.cs
@@ -11,7 +11,7 @@ public class SerializationTests
     [MethodDataSource(typeof(WaterLevelCheckTestData), "GetEnumerator")]
     public async Task SerializeAndDeserializeShouldWork(string expression, bool expected, double inputValue)
     {
-        var compiled = LogicalExpressionFactory.Create(expression, ct: CancellationToken.None);
+        var compiled = LogicalExpressionFactory.Create(expression, cancellationToken: CancellationToken.None);
         var serialized = JsonSerializer.Serialize(compiled);
         var deserialized = JsonSerializer.Deserialize<LogicalExpression>(serialized);
 
@@ -41,7 +41,7 @@ public class SerializationTests
     [Test]
     public async Task SystemTextJsonPolymorphicSerializeAndDeserializeShouldWork()
     {
-        var expression = LogicalExpressionFactory.Create("1 == 1", ct: CancellationToken.None);
+        var expression = LogicalExpressionFactory.Create("1 == 1", cancellationToken: CancellationToken.None);
         var expressionJson = JsonSerializer.Serialize(expression);
         await Assert.That(JsonSerializer.Deserialize<LogicalExpression>(expressionJson) is BinaryExpression).IsTrue();
     }
@@ -169,7 +169,7 @@ public class SerializationTests
 
         var expression = new Expression("[ValueA] + [ValueB]", context);
 
-        await Assert.That(expression.ToExpressionString(evaluateParameters: true, ct: CancellationToken.None)).IsEqualTo("10 + 15");
+        await Assert.That(expression.ToExpressionString(evaluateParameters: true, cancellationToken: CancellationToken.None)).IsEqualTo("10 + 15");
     }
 
     [Test]

--- a/test/NCalc.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/NCalc.Tests/ServiceCollectionExtensionsTests.cs
@@ -106,20 +106,20 @@ public class ServiceCollectionExtensionsTests
 
     private class CustomLogicalExpressionFactory : ILogicalExpressionFactory
     {
-        public LogicalExpression Create(string expression, ExpressionOptions options, CancellationToken ct = default) => throw new NCalcException("Stub method intented for testing.");
+        public LogicalExpression Create(string expression, ExpressionOptions options, CancellationToken cancellationToken = default) => throw new NCalcException("Stub method intented for testing.");
 
-        public LogicalExpression Create(string expression, CultureInfo cultureInfo, ExpressionOptions options = ExpressionOptions.None, CancellationToken ct = default)
+        public LogicalExpression Create(string expression, CultureInfo cultureInfo, ExpressionOptions options = ExpressionOptions.None, CancellationToken cancellationToken = default)
             => throw new NCalcException("Stub method intented for testing.");
     }
 
     private class CustomVisitor(ExpressionContext context) : EvaluationVisitor(context)
     {
-        public override ValueTask<object> Visit(ValueExpression expression, CancellationToken ct = default)
+        public override ValueTask<object> Visit(ValueExpression expression, CancellationToken cancellationToken = default)
         {
             if (expression.Value is 42)
                 return ValueTask.FromResult<object>("The answer");
 
-            return base.Visit(expression, ct);
+            return base.Visit(expression, cancellationToken);
         }
     }
 


### PR DESCRIPTION
Rename CancellationToken parameters from ct to cancellationToken to align with Microsoft naming conventions.