### PR TITLE
Add GetBuiltInFunctionNames method

### DIFF
--- a/src/NCalc.Core/Helpers/BuiltInFunctionHelper.cs
+++ b/src/NCalc.Core/Helpers/BuiltInFunctionHelper.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using NCalc.Exceptions;
 using NCalc.Handlers;
 
@@ -5,6 +6,35 @@ namespace NCalc.Helpers;
 
 public static class BuiltInFunctionHelper
 {
+    private static readonly IReadOnlyList<string> _builtInFunctionNames =
+        new ReadOnlyCollection<string>([
+            "abs",
+            "acos",
+            "asin",
+            "atan",
+            "atan2",
+            "ceiling",
+            "cos",
+            "exp",
+            "floor",
+            "ieeeremainder",
+            "ln",
+            "log",
+            "log10",
+            "pow",
+            "round",
+            "sign",
+            "sqrt",
+            "tan",
+            "truncate",
+            "max",
+            "min",
+            "if",
+            "in",
+            "ifs"
+        ]);
+    public static IReadOnlyList<string> GetBuiltInFunctionNames() => _builtInFunctionNames;
+
     public static object? Evaluate(
         string functionName,
         FunctionData functionData)


### PR DESCRIPTION
Added the GetBuiltInFunctionNames() method to publicly expose the list of supported built-in functions.
Motivation: Allows consumer applications to validate expressions preventively before execution or Power UI components for autocomplete (IntelliSense) or dynamic documentation.

Implementation Details:

Returns an immutable collection to prevent external modification.

Cached statically to avoid redundant memory allocations per call.