### PR TITLE
Move 'if', 'in' functions to the top of Evaluate and EvaluateAsync in BultiIn

### DIFF
--- a/src/NCalc.Core/Helpers/BuiltInFunctionHelper.cs
+++ b/src/NCalc.Core/Helpers/BuiltInFunctionHelper.cs
@@ -13,6 +13,30 @@ public static class BuiltInFunctionHelper
         var caseInsensitive = context.Options.HasFlag(ExpressionOptions.IgnoreCaseAtBuiltInFunctions);
         var comparison = caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 
+        if (functionName.Equals("if", comparison))
+        {
+            if (functionData.Count != 3)
+                throw new NCalcEvaluationException("if() takes exactly 3 arguments");
+
+            var cond = Convert.ToBoolean(functionData.Evaluate(0), context.CultureInfo);
+            return cond ? functionData.Evaluate(1) : functionData.Evaluate(2);
+        }
+
+        if (functionName.Equals("in", comparison))
+        {
+            if (functionData.Count < 2)
+                throw new NCalcEvaluationException("in() takes at least 2 arguments");
+
+            var parameter = functionData.Evaluate(0);
+            for (var i = 1; i < functionData.Count; i++)
+            {
+                if (TypeHelper.CompareUsingMostPreciseType(parameter, functionData.Evaluate(i), context) == ComparisonResult.Equal)
+                    return true;
+            }
+
+            return false;
+        }
+
         if (functionName.Equals("Abs", comparison))
         {
             if (functionData.Count != 1)
@@ -187,31 +211,7 @@ public static class BuiltInFunctionHelper
 
             return null;
         }
-
-        if (functionName.Equals("if", comparison))
-        {
-            if (functionData.Count != 3)
-                throw new NCalcEvaluationException("if() takes exactly 3 arguments");
-
-            var cond = Convert.ToBoolean(functionData.Evaluate(0), context.CultureInfo);
-            return cond ? functionData.Evaluate(1) : functionData.Evaluate(2);
-        }
-
-        if (functionName.Equals("in", comparison))
-        {
-            if (functionData.Count < 2)
-                throw new NCalcEvaluationException("in() takes at least 2 arguments");
-
-            var parameter = functionData.Evaluate(0);
-            for (var i = 1; i < functionData.Count; i++)
-            {
-                if (TypeHelper.CompareUsingMostPreciseType(parameter, functionData.Evaluate(i), context) == ComparisonResult.Equal)
-                    return true;
-            }
-
-            return false;
-        }
-
+        
         throw new NCalcFunctionNotFoundException(functionName);
     }
 
@@ -222,6 +222,30 @@ public static class BuiltInFunctionHelper
         var context = functionData.Context;
         var caseInsensitive = context.Options.HasFlag(ExpressionOptions.IgnoreCaseAtBuiltInFunctions);
         var comparison = caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+        if (functionName.Equals("if", comparison))
+        {
+            if (functionData.Count != 3)
+                throw new NCalcEvaluationException("if() takes exactly 3 arguments");
+
+            var cond = Convert.ToBoolean(await functionData.EvaluateAsync(0), context.CultureInfo);
+            return cond ? await functionData.EvaluateAsync(1) : await functionData.EvaluateAsync(2);
+        }
+
+        if (functionName.Equals("in", comparison))
+        {
+            if (functionData.Count < 2)
+                throw new NCalcEvaluationException("in() takes at least 2 arguments");
+
+            var parameter = await functionData.EvaluateAsync(0);
+            for (var i = 1; i < functionData.Count; i++)
+            {
+                if (TypeHelper.CompareUsingMostPreciseType(parameter, await functionData.EvaluateAsync(i), context) == ComparisonResult.Equal)
+                    return true;
+            }
+
+            return false;
+        }
 
         if (functionName.Equals("Abs", comparison))
         {
@@ -396,30 +420,6 @@ public static class BuiltInFunctionHelper
             }
 
             return null;
-        }
-
-        if (functionName.Equals("if", comparison))
-        {
-            if (functionData.Count != 3)
-                throw new NCalcEvaluationException("if() takes exactly 3 arguments");
-
-            var cond = Convert.ToBoolean(await functionData.EvaluateAsync(0), context.CultureInfo);
-            return cond ? await functionData.EvaluateAsync(1) : await functionData.EvaluateAsync(2);
-        }
-
-        if (functionName.Equals("in", comparison))
-        {
-            if (functionData.Count < 2)
-                throw new NCalcEvaluationException("in() takes at least 2 arguments");
-
-            var parameter = await functionData.EvaluateAsync(0);
-            for (var i = 1; i < functionData.Count; i++)
-            {
-                if (TypeHelper.CompareUsingMostPreciseType(parameter, await functionData.EvaluateAsync(i), context) == ComparisonResult.Equal)
-                    return true;
-            }
-
-            return false;
         }
 
         throw new NCalcFunctionNotFoundException(functionName);


### PR DESCRIPTION
Since logical and conditional operations are among the most frequently executed functions in expression evaluations, checking them first reduces string comparison overhead for the majority of execution paths.