### PR TITLE
Changed IList to IReadOnlyList

### DIFF
--- a/src/NCalc.Core/Handlers/FunctionData.cs
+++ b/src/NCalc.Core/Handlers/FunctionData.cs
@@ -10,7 +10,7 @@ public class FunctionData(
     ILogicalExpressionVisitor<object?> syncVisitor,
     ILogicalExpressionVisitor<Task<object?>>? asyncVisitor,
     CancellationToken cancellationToken)
-    : IList<LogicalExpression>
+    : IReadOnlyList<LogicalExpression>
 {
     private LogicalExpressionList Arguments { get; } = arguments;
     private ILogicalExpressionVisitor<object?> SyncVisitor { get; } = syncVisitor;
@@ -21,11 +21,7 @@ public class FunctionData(
     public ExpressionContext Context { get; } = context;
     public CancellationToken CancellationToken { get; } = cancellationToken;
 
-    public LogicalExpression this[int index]
-    {
-        get => Arguments[index];
-        set => Arguments[index] = value;
-    }
+    public LogicalExpression this[int index] => Arguments[index];
 
     public Task<object?> EvaluateAsync(int index)
     {
@@ -40,35 +36,7 @@ public class FunctionData(
     {
         return Arguments[index].Accept(SyncVisitor);
     }
-
-    public void Add(LogicalExpression item) => Arguments.Add(item);
-
-    public void Clear() => Arguments.Clear();
-
-    public bool Contains(LogicalExpression item) => Arguments.Contains(item);
-
-    public void CopyTo(LogicalExpression[] array, int arrayIndex) => Arguments.CopyTo(array, arrayIndex);
-
-    public bool Remove(LogicalExpression item) => Arguments.Remove(item);
-
     public int Count => Arguments.Count;
-
-    public bool IsReadOnly => Arguments.IsReadOnly;
-
-    public int IndexOf(LogicalExpression item)
-    {
-        return Arguments.IndexOf(item);
-    }
-
-    public void Insert(int index, LogicalExpression item)
-    {
-        Arguments.Insert(index, item);
-    }
-
-    public void RemoveAt(int index)
-    {
-        Arguments.RemoveAt(index);
-    }
 
     public IEnumerator<LogicalExpression> GetEnumerator()
     {

--- a/src/NCalc.Core/Visitors/AsyncEvaluationVisitor.cs
+++ b/src/NCalc.Core/Visitors/AsyncEvaluationVisitor.cs
@@ -101,11 +101,14 @@ public class AsyncEvaluationVisitor(ExpressionContext context, CancellationToken
 
     public virtual async Task<object?> Visit(LogicalExpressionList list)
     {
-        List<object?> result = [];
+        if (list.Count == 0) return Array.Empty<object?>();
 
-        foreach (var value in list)
+        var listCount = list.Count;
+        var result = new object?[listCount];
+
+        for (var index = 0; index < listCount; index++)
         {
-            result.Add(await EvaluateAsync(value));
+            result[index] = await EvaluateAsync(list[index]);
         }
 
         return result;

--- a/src/NCalc.Core/Visitors/EvaluationVisitor.cs
+++ b/src/NCalc.Core/Visitors/EvaluationVisitor.cs
@@ -88,11 +88,16 @@ public class EvaluationVisitor(ExpressionContext context, CancellationToken canc
 
     public virtual object? Visit(LogicalExpressionList list)
     {
-        List<object?> result = [];
+        if (list.Count == 0) return Array.Empty<object?>();
 
-        foreach (var value in list)
+        var expressions = list.AsSpan();
+        var listCount = expressions.Length;
+
+        var result = new object?[listCount];
+
+        for (var index = 0; index < listCount; index++)
         {
-            result.Add(value.Accept(this));
+            result[index] = expressions[index].Accept(this);
         }
 
         return result;

--- a/src/NCalc.Domain/LogicalExpressionList.cs
+++ b/src/NCalc.Domain/LogicalExpressionList.cs
@@ -2,32 +2,29 @@ using NCalc.Visitors;
 
 namespace NCalc;
 
-public sealed class LogicalExpressionList : LogicalExpression, IList<LogicalExpression>
+public sealed class LogicalExpressionList : LogicalExpression, IReadOnlyList<LogicalExpression>
 {
-    private readonly List<LogicalExpression> _list;
+    private readonly LogicalExpression[] _list;
 
     public LogicalExpressionList()
     {
         _list = [];
     }
 
-    public LogicalExpressionList(IEnumerable<LogicalExpression> values)
+    public LogicalExpressionList(IReadOnlyList<LogicalExpression> values)
     {
-        _list = values.ToList();
+        _list = values.ToArray();
     }
 
-    public int Count => _list.Count;
-    public bool IsReadOnly => false;
+    public int Count => _list.Length;
 
-    public LogicalExpression this[int index]
-    {
-        get => _list[index];
-        set => _list[index] = value;
-    }
+    public Span<LogicalExpression> AsSpan() => _list.AsSpan();
+
+    public LogicalExpression this[int index] => _list[index];
 
     public IEnumerator<LogicalExpression> GetEnumerator()
     {
-        return _list.GetEnumerator();
+        return ((IEnumerable<LogicalExpression>)_list).GetEnumerator();
     }
 
     IEnumerator IEnumerable.GetEnumerator()
@@ -35,48 +32,8 @@ public sealed class LogicalExpressionList : LogicalExpression, IList<LogicalExpr
         return GetEnumerator();
     }
 
-    public void Add(LogicalExpression item)
-    {
-        _list.Add(item);
-    }
-
-    public void Clear()
-    {
-        _list.Clear();
-    }
-
-    public bool Contains(LogicalExpression item)
-    {
-        return _list.Contains(item);
-    }
-
-    public void CopyTo(LogicalExpression[] array, int arrayIndex)
-    {
-        _list.CopyTo(array, arrayIndex);
-    }
-
-    public bool Remove(LogicalExpression item)
-    {
-        return _list.Remove(item);
-    }
-
-    public int IndexOf(LogicalExpression item)
-    {
-        return _list.IndexOf(item);
-    }
-
-    public void Insert(int index, LogicalExpression item)
-    {
-        _list.Insert(index, item);
-    }
-
-    public void RemoveAt(int index)
-    {
-        _list.RemoveAt(index);
-    }
-
     public override T Accept<T>(ILogicalExpressionVisitor<T> visitor)
     {
         return visitor.Visit(this);
     }
-}
+};

--- a/test/NCalc.Tests/SerializationTests.cs
+++ b/test/NCalc.Tests/SerializationTests.cs
@@ -92,15 +92,15 @@ public class SerializationTests
     [Test]
     public async Task Function_Serialization_Test()
     {
-        await Assert.That(new Function(new Identifier("test"), [
+        await Assert.That(new Function(new Identifier("test"), new LogicalExpressionList([
             new BinaryExpression(BinaryExpressionType.And, new ValueExpression(true), new ValueExpression(false)),
             new UnaryExpression(UnaryExpressionType.Negate,
                 new BinaryExpression(BinaryExpressionType.And, new ValueExpression(true), new ValueExpression(false)))
-        ]).ToExpressionString()).IsEqualTo("test(True and False, -(True and False))");
+        ])).ToExpressionString()).IsEqualTo("test(True and False, -(True and False))");
 
-        await Assert.That(new Function(new Identifier("Sum"), [
+        await Assert.That(new Function(new Identifier("Sum"), new LogicalExpressionList([
             new BinaryExpression(BinaryExpressionType.Plus, new ValueExpression(1), new ValueExpression(2))
-        ]).ToExpressionString()).IsEqualTo("Sum(1 + 2)");
+        ])).ToExpressionString()).IsEqualTo("Sum(1 + 2)");
     }
 
     [Test]


### PR DESCRIPTION
Refactors the representation of logical lists and function arguments to use IReadOnlyList and array-backed storage, reducing unnecessary mutation and simplifying expression evaluation.
List evaluation was also updated to iterate directly over the internal buffer, with less overhead and fewer allocations.