### PR TITLE
Fix: Honor StringComparer at `in` comparisons when NoStringTypeCoercion is set

### DIFF
--- a/src/NCalc.Core/Helpers/EvaluationHelper.cs
+++ b/src/NCalc.Core/Helpers/EvaluationHelper.cs
@@ -129,6 +129,9 @@ public static class EvaluationHelper
 
         if (noStringTypeCoercion)
         {
+            if (leftValue is string leftOnlyString && rightValue is string rightOnlyString)
+                return options.StringComparer.Equals(leftOnlyString, rightOnlyString);
+
             if (leftValue is string || rightValue is string)
                 return EqualityComparer<object?>.Default.Equals(leftValue, rightValue);
 

--- a/test/NCalc.Tests/NoStringTypeCoercionTests.cs
+++ b/test/NCalc.Tests/NoStringTypeCoercionTests.cs
@@ -48,4 +48,32 @@ public class NoStringTypeCoercionTests
     {
         await Assert.That(new Expression(expression).Evaluate(CancellationToken.None)).IsEqualTo(expected);
     }
+
+    [Test]
+    [Arguments("'md' in ('MD','DO','PA')", true)]
+    [Arguments("'MD' in ('MD','DO','PA')", true)]
+    [Arguments("'xx' in ('MD','DO','PA')", false)]
+    [Arguments("'md' not in ('MD','DO','PA')", false)]
+    public async Task ShouldRespectStringComparerAtInOperatorWhenCoercionIsDisabled(string expression, bool expected)
+    {
+        // Both operands are strings, so no coercion is involved. Disabling coercion must not
+        // change how two strings are compared to each other.
+        await Assert.That(new Expression(expression,
+                ExpressionOptions.NoStringTypeCoercion | ExpressionOptions.CaseInsensitiveStringComparer)
+            .Evaluate(CancellationToken.None)).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task ShouldAgreeWithEqualityAtInOperatorWhenCoercionIsDisabled()
+    {
+        const ExpressionOptions options =
+            ExpressionOptions.NoStringTypeCoercion | ExpressionOptions.CaseInsensitiveStringComparer;
+
+        // Note: a single parenthesised value parses as a string, which routes to the substring
+        // overload of 'in'. Two values keep this on the list path being asserted here.
+        var equality = new Expression("'md' == 'MD'", options).Evaluate(CancellationToken.None);
+        var inOperator = new Expression("'md' in ('MD','DO')", options).Evaluate(CancellationToken.None);
+
+        await Assert.That(inOperator).IsEqualTo(equality);
+    }
 }


### PR DESCRIPTION
When both operands are strings, comparing them involves no coercion to another type, so NoStringTypeCoercion should not change how they compare.
Since 6.3.2 the flag short-circuited string comparisons to ordinal equality, making `'md' in ('MD','DO')` false under a case-insensitive StringComparer while `'md' == 'MD'` stayed true.

Mixed-type operands are untouched, so disabling coercion still rejects `1 in ('1')` as before.

Fixes #611 